### PR TITLE
Date utils

### DIFF
--- a/.changeset/moody-tips-boil.md
+++ b/.changeset/moody-tips-boil.md
@@ -1,0 +1,5 @@
+---
+'@navikt/sif-common-utils': patch
+---
+
+Endre til å bruke .utc i dateToISODate - da likt som det har vært i sif-common-core

--- a/packages/sif-common-utils/src/dateUtils.ts
+++ b/packages/sif-common-utils/src/dateUtils.ts
@@ -21,8 +21,9 @@ export const date1YearFromNow = dayjs().add(1, 'year').endOf('day').toDate();
 export const dateToISODate = (date: Date): ISODate => dayjs(date).format(ISODateFormat);
 
 export const ISODateToDate = (isoDate: ISODate): Date => {
-    return dayjs(isoDate).toDate();
+    return dayjs.utc(isoDate, ISODateFormat).toDate();
 };
+
 export const getISOWeekdayFromISODate = (isoDate: ISODate): number => {
     return dayjs(ISODateToDate(isoDate)).isoWeekday();
 };


### PR DESCRIPTION
Legge til .utc i funksjonen dateToISODate i dateUtils. Da er denne lik slik den alltid har vært i sif-common-core.