### PR TITLE
Bugfix - telle dager riktig

### DIFF
--- a/.changeset/bright-knives-dance.md
+++ b/.changeset/bright-knives-dance.md
@@ -1,0 +1,5 @@
+---
+'@navikt/sif-common-utils': minor
+---
+
+Ta høyde for ulikt tidspunkt på fra og til dato når en teller dager i en periode.

--- a/packages/sif-common-utils/src/__tests__/dateRangeUtils.test.ts
+++ b/packages/sif-common-utils/src/__tests__/dateRangeUtils.test.ts
@@ -342,6 +342,13 @@ describe('dateRangeUtils', () => {
                 });
                 expect(result).toBe(2);
             });
+            it('returns 2 even if time of day 1 is after time of day 2', () => {
+                const result = getNumberOfDaysInDateRange({
+                    from: new Date(2022, 1, 1, 5),
+                    to: new Date(2022, 1, 2, 2),
+                });
+                expect(result).toBe(2);
+            });
             it('returns 3 when to date is two days after from date', () => {
                 const result = getNumberOfDaysInDateRange({
                     from: ISODateToDate('2021-02-01'),

--- a/packages/sif-common-utils/src/dateRangeUtils.ts
+++ b/packages/sif-common-utils/src/dateRangeUtils.ts
@@ -286,7 +286,7 @@ export const getYearsInDateRanges = (dateRanges: DateRange[]): number[] =>
 export const getNumberOfDaysInDateRange = (dateRange: DateRange, onlyWeekDays = false): number =>
     onlyWeekDays
         ? getDatesInDateRange(dateRange, onlyWeekDays).length
-        : Math.abs(dayjs(dateRange.to).diff(dateRange.from, 'days')) + 1;
+        : Math.abs(dayjs(dateRange.to).startOf('day').diff(dayjs(dateRange.from).startOf('day'), 'days')) + 1;
 
 /**
  * Gets a dateRange spanning all @ranges


### PR DESCRIPTION
Telling av dager tok ikke høyde for at klokkeslettet kunne være ulikt. Dette gjorde at dersom det ikke var ett helt døgn (i tid), mellom to datoer, så antall dager 0.