### PR TITLE
Bugfix tilgangskontroll i endringsdialog

### DIFF
--- a/.changeset/modern-walls-juggle.md
+++ b/.changeset/modern-walls-juggle.md
@@ -1,0 +1,5 @@
+---
+'@navikt/endringsmelding-pleiepenger': patch
+---
+
+Bugfix på at all mistmatch mellom arbeidsgivere i sak og registrerte arbeidsforhold ble tolket som harUkjentArbeidsforhold

--- a/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsaktivitet-uten-arbeidsgiver/arbeidsgiver-mock.json
+++ b/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsaktivitet-uten-arbeidsgiver/arbeidsgiver-mock.json
@@ -1,0 +1,6 @@
+{
+    "organisasjoner": [
+        { "navn": "Dykkert svømmeutstyr", "organisasjonsnummer": "947064649", "ansattFom": "2008-10-01" },
+        { "navn": "Vinge flyfly", "organisasjonsnummer": "947064640", "ansattFom": "2008-10-01" }
+    ]
+}

--- a/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsaktivitet-uten-arbeidsgiver/sak-mock.json
+++ b/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsaktivitet-uten-arbeidsgiver/sak-mock.json
@@ -1,0 +1,350 @@
+[
+    {
+        "barn": {
+            "fødselsdato": "2017-03-03",
+            "fornavn": "Nora",
+            "mellomnavn": null,
+            "etternavn": "Nordmann",
+            "aktørId": "2559652436225",
+            "identitetsnummer": "03831799748"
+        },
+        "søknad": {
+            "søknadId": "generert",
+            "versjon": "1.0.0.",
+            "mottattDato": "2023-01-18T08:13:37.525Z",
+            "søker": { "norskIdentitetsnummer": "00000000000" },
+            "ytelse": {
+                "type": "PLEIEPENGER_SYKT_BARN",
+                "barn": { "norskIdentitetsnummer": "00000000000", "fødselsdato": null },
+                "søknadsperiode": ["2022-01-01/2023-03-31"],
+                "endringsperiode": [],
+                "trekkKravPerioder": [],
+                "opptjeningAktivitet": {},
+                "dataBruktTilUtledning": null,
+                "infoFraPunsj": null,
+                "bosteder": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                "utenlandsopphold": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                "beredskap": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                "nattevåk": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                "tilsynsordning": {
+                    "perioder": {
+                        "2022-12-01/2023-01-31": { "etablertTilsynTimerPerDag": "PT8H" },
+                        "2023-02-14/2023-03-16": { "etablertTilsynTimerPerDag": "PT8H" }
+                    }
+                },
+                "lovbestemtFerie": { "perioder": {} },
+                "arbeidstid": {
+                    "arbeidstakerList": [
+                        {
+                            "norskIdentitetsnummer": null,
+                            "organisasjonsnummer": "123123123",
+                            "arbeidstidInfo": {
+                                "perioder": {
+                                    "2022-01-01/2022-03-25": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    }
+                                }
+                            }
+                        },
+
+                        {
+                            "norskIdentitetsnummer": null,
+                            "organisasjonsnummer": "947064649",
+                            "arbeidstidInfo": {
+                                "perioder": {
+                                    "2022-01-01/2022-03-25": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-03-28/2022-04-01": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-04-04/2022-04-08": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-04-11/2022-04-15": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-04-18/2022-04-22": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-04-25/2022-04-29": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-02/2022-05-06": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-09/2022-05-13": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-16/2022-05-20": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-23/2022-05-27": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-30/2022-06-03": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-06-06/2022-06-10": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-06-13/2022-06-17": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-06-20/2022-06-24": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-06-27/2022-06-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-01/2022-07-01": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-07-04/2022-07-07": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-08/2022-07-08": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-07-11/2022-07-14": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-15/2022-07-15": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-07-18/2022-07-21": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-22/2022-07-22": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-07-25/2022-07-28": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-29/2022-07-29": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-01/2022-08-04": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-08-05/2022-08-05": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-08/2022-08-11": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-08-12/2022-08-12": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-15/2022-08-18": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-08-19/2022-08-19": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-22/2022-08-25": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-08-26/2022-08-26": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-29/2022-08-31": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-01/2022-09-01": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT3H"
+                                    },
+                                    "2022-09-02/2022-09-02": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT4H30M"
+                                    },
+                                    "2022-09-05/2022-09-05": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-06/2022-09-06": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT2H30M"
+                                    },
+                                    "2022-09-07/2022-09-08": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-09/2022-09-09": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT5H"
+                                    },
+                                    "2022-09-12/2022-09-13": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-14/2022-09-14": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT4H"
+                                    },
+                                    "2022-09-15/2022-09-15": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT3H30M"
+                                    },
+                                    "2022-09-16/2022-09-16": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-09-19/2022-09-22": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-23/2022-09-23": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-09-26/2022-09-29": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-30/2022-09-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-10-03/2022-12-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "norskIdentitetsnummer": null,
+                            "organisasjonsnummer": "947064640",
+                            "arbeidstidInfo": {
+                                "perioder": {
+                                    "2022-09-01/2022-09-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-10-03/2022-12-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2023-01-01/2023-01-15": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2023-01-16/2023-03-12": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT4H30M"
+                                    },
+                                    "2023-03-13/2023-03-31": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "frilanserArbeidstidInfo": {
+                        "perioder": {
+                            "2022-06-25/2022-12-31": {
+                                "jobberNormaltTimerPerDag": "PT0S",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-01-02/2023-01-06": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-01-09/2023-01-13": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-01-16/2023-01-20": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-01-23/2023-01-27": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-01-30/2023-02-03": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-02-06/2023-02-10": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-02-13/2023-02-17": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-02-20/2023-02-24": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-02-27/2023-03-03": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-03-06/2023-03-10": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-03-13/2023-03-17": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-03-20/2023-03-24": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-03-27/2023-03-31": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            }
+                        }
+                    },
+                    "selvstendigNæringsdrivendeArbeidstidInfo": {}
+                },
+                "uttak": { "perioder": {} },
+                "omsorg": { "relasjonTilBarnet": null, "beskrivelseAvOmsorgsrollen": null }
+            },
+            "språk": "nb",
+            "journalposter": [],
+            "begrunnelseForInnsending": { "tekst": null }
+        }
+    }
+]

--- a/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsaktivitet-uten-arbeidsgiver/søker-mock.json
+++ b/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsaktivitet-uten-arbeidsgiver/søker-mock.json
@@ -1,0 +1,8 @@
+{
+    "aktørId": "234",
+    "fødselsnummer": "30086421581",
+    "fødselsdato": "2001-02-01",
+    "fornavn": "ArbFri",
+    "mellomnavn": null,
+    "etternavn": "KRONJUVEL"
+}

--- a/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsgiver-ikke-i-sak/arbeidsgiver-mock.json
+++ b/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsgiver-ikke-i-sak/arbeidsgiver-mock.json
@@ -1,0 +1,7 @@
+{
+    "organisasjoner": [
+        { "navn": "Dykkert svømmeutstyr", "organisasjonsnummer": "947064649", "ansattFom": "2008-10-01" },
+        { "navn": "Vinge flyfly", "organisasjonsnummer": "947064640", "ansattFom": "2008-10-01" },
+        { "navn": "Ikke i sak AS", "organisasjonsnummer": "947064642", "ansattFom": "2008-10-01" }
+    ]
+}

--- a/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsgiver-ikke-i-sak/sak-mock.json
+++ b/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsgiver-ikke-i-sak/sak-mock.json
@@ -1,0 +1,337 @@
+[
+    {
+        "barn": {
+            "fødselsdato": "2017-03-03",
+            "fornavn": "Nora",
+            "mellomnavn": null,
+            "etternavn": "Nordmann",
+            "aktørId": "2559652436225",
+            "identitetsnummer": "03831799748"
+        },
+        "søknad": {
+            "søknadId": "generert",
+            "versjon": "1.0.0.",
+            "mottattDato": "2023-01-18T08:13:37.525Z",
+            "søker": { "norskIdentitetsnummer": "00000000000" },
+            "ytelse": {
+                "type": "PLEIEPENGER_SYKT_BARN",
+                "barn": { "norskIdentitetsnummer": "00000000000", "fødselsdato": null },
+                "søknadsperiode": ["2022-01-01/2023-03-31"],
+                "endringsperiode": [],
+                "trekkKravPerioder": [],
+                "opptjeningAktivitet": {},
+                "dataBruktTilUtledning": null,
+                "infoFraPunsj": null,
+                "bosteder": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                "utenlandsopphold": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                "beredskap": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                "nattevåk": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                "tilsynsordning": {
+                    "perioder": {
+                        "2022-12-01/2023-01-31": { "etablertTilsynTimerPerDag": "PT8H" },
+                        "2023-02-14/2023-03-16": { "etablertTilsynTimerPerDag": "PT8H" }
+                    }
+                },
+                "lovbestemtFerie": { "perioder": {} },
+                "arbeidstid": {
+                    "arbeidstakerList": [
+                        {
+                            "norskIdentitetsnummer": null,
+                            "organisasjonsnummer": "947064649",
+                            "arbeidstidInfo": {
+                                "perioder": {
+                                    "2022-01-01/2022-03-25": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-03-28/2022-04-01": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-04-04/2022-04-08": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-04-11/2022-04-15": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-04-18/2022-04-22": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-04-25/2022-04-29": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-02/2022-05-06": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-09/2022-05-13": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-16/2022-05-20": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-23/2022-05-27": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-05-30/2022-06-03": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-06-06/2022-06-10": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-06-13/2022-06-17": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-06-20/2022-06-24": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-06-27/2022-06-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-01/2022-07-01": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-07-04/2022-07-07": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-08/2022-07-08": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-07-11/2022-07-14": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-15/2022-07-15": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-07-18/2022-07-21": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-22/2022-07-22": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-07-25/2022-07-28": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-07-29/2022-07-29": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-01/2022-08-04": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-08-05/2022-08-05": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-08/2022-08-11": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-08-12/2022-08-12": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-15/2022-08-18": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-08-19/2022-08-19": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-22/2022-08-25": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-08-26/2022-08-26": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-08-29/2022-08-31": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-01/2022-09-01": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT3H"
+                                    },
+                                    "2022-09-02/2022-09-02": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT4H30M"
+                                    },
+                                    "2022-09-05/2022-09-05": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-06/2022-09-06": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT2H30M"
+                                    },
+                                    "2022-09-07/2022-09-08": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-09/2022-09-09": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT5H"
+                                    },
+                                    "2022-09-12/2022-09-13": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-14/2022-09-14": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT4H"
+                                    },
+                                    "2022-09-15/2022-09-15": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT3H30M"
+                                    },
+                                    "2022-09-16/2022-09-16": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-09-19/2022-09-22": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-23/2022-09-23": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-09-26/2022-09-29": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT0S"
+                                    },
+                                    "2022-09-30/2022-09-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT7H30M"
+                                    },
+                                    "2022-10-03/2022-12-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "norskIdentitetsnummer": null,
+                            "organisasjonsnummer": "947064640",
+                            "arbeidstidInfo": {
+                                "perioder": {
+                                    "2022-09-01/2022-09-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2022-10-03/2022-12-30": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2023-01-01/2023-01-15": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    },
+                                    "2023-01-16/2023-03-12": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT4H30M"
+                                    },
+                                    "2023-03-13/2023-03-31": {
+                                        "jobberNormaltTimerPerDag": "PT7H30M",
+                                        "faktiskArbeidTimerPerDag": "PT1H30M"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "frilanserArbeidstidInfo": {
+                        "perioder": {
+                            "2022-06-25/2022-12-31": {
+                                "jobberNormaltTimerPerDag": "PT0S",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-01-02/2023-01-06": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-01-09/2023-01-13": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-01-16/2023-01-20": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-01-23/2023-01-27": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-01-30/2023-02-03": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-02-06/2023-02-10": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-02-13/2023-02-17": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-02-20/2023-02-24": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-02-27/2023-03-03": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-03-06/2023-03-10": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT3H"
+                            },
+                            "2023-03-13/2023-03-17": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-03-20/2023-03-24": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            },
+                            "2023-03-27/2023-03-31": {
+                                "jobberNormaltTimerPerDag": "PT3H",
+                                "faktiskArbeidTimerPerDag": "PT0S"
+                            }
+                        }
+                    },
+                    "selvstendigNæringsdrivendeArbeidstidInfo": {}
+                },
+                "uttak": { "perioder": {} },
+                "omsorg": { "relasjonTilBarnet": null, "beskrivelseAvOmsorgsrollen": null }
+            },
+            "språk": "nb",
+            "journalposter": [],
+            "begrunnelseForInnsending": { "tekst": null }
+        }
+    }
+]

--- a/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsgiver-ikke-i-sak/søker-mock.json
+++ b/apps/endringsmelding-pleiepenger/mocks/data/scenario/arbeidsgiver-ikke-i-sak/søker-mock.json
@@ -1,0 +1,8 @@
+{
+    "aktørId": "234",
+    "fødselsnummer": "30086421581",
+    "fødselsdato": "2001-02-01",
+    "fornavn": "ArbFri",
+    "mellomnavn": null,
+    "etternavn": "KRONJUVEL"
+}

--- a/apps/endringsmelding-pleiepenger/mocks/msw/handlers.ts
+++ b/apps/endringsmelding-pleiepenger/mocks/msw/handlers.ts
@@ -46,6 +46,16 @@ const mockData = {
         sak: require('../data/scenario/ingen-sak/sak-mock.json'),
         arbeidsgiver: require('../data/scenario/ingen-sak/arbeidsgiver-mock.json'),
     },
+    ['arbeidsgiver-ikke-i-sak']: {
+        søker: require('../data/scenario/arbeidsgiver-ikke-i-sak/søker-mock.json'),
+        sak: require('../data/scenario/arbeidsgiver-ikke-i-sak/sak-mock.json'),
+        arbeidsgiver: require('../data/scenario/arbeidsgiver-ikke-i-sak/arbeidsgiver-mock.json'),
+    },
+    ['arbeidsaktivitet-uten-arbeidsgiver']: {
+        søker: require('../data/scenario/arbeidsaktivitet-uten-arbeidsgiver/søker-mock.json'),
+        sak: require('../data/scenario/arbeidsaktivitet-uten-arbeidsgiver/sak-mock.json'),
+        arbeidsgiver: require('../data/scenario/arbeidsaktivitet-uten-arbeidsgiver/arbeidsgiver-mock.json'),
+    },
     ['ugyldig-k9-format']: {
         søker: require('../data/scenario/ugyldig-k9-format/søker-mock.json'),
         sak: require('../data/scenario/ugyldig-k9-format/sak-mock.json'),

--- a/apps/endringsmelding-pleiepenger/src/app/dev/scenarioer.ts
+++ b/apps/endringsmelding-pleiepenger/src/app/dev/scenarioer.ts
@@ -47,6 +47,16 @@ export const scenarioer: Scenario[] = [
         harTilgang: false,
     },
     {
+        name: 'Arbeidsgiver som ikke er i sak',
+        value: 'arbeidsgiver-ikke-i-sak',
+        harTilgang: false,
+    },
+    {
+        name: 'Arbeidsaktivitet uten arbeidsgiver',
+        value: 'arbeidsaktivitet-uten-arbeidsgiver',
+        harTilgang: false,
+    },
+    {
         name: 'Ugyldig k9format',
         value: 'ugyldig-k9-format',
         harTilgang: false,

--- a/apps/endringsmelding-pleiepenger/src/app/pages/ingen-tilgang/IngenTilgangPage.tsx
+++ b/apps/endringsmelding-pleiepenger/src/app/pages/ingen-tilgang/IngenTilgangPage.tsx
@@ -46,7 +46,7 @@ const getÅrsakMelding = (årsak: IngenTilgangÅrsak) => {
                     </p>
                 </BodyLong>
             );
-        case IngenTilgangÅrsak.harArbeidsgiverSomIkkeErISak:
+        case IngenTilgangÅrsak.harArbeidsgiverUtenArbeidsaktivitet:
             return (
                 <BodyLong as="div" data-testid="nyttArbeidsforhold">
                     <p>
@@ -60,7 +60,7 @@ const getÅrsakMelding = (årsak: IngenTilgangÅrsak) => {
                     </p>
                 </BodyLong>
             );
-        case IngenTilgangÅrsak.harUkjentArbeidsforhold:
+        case IngenTilgangÅrsak.harArbeidsaktivitetUtenArbeidsgiver:
             return (
                 <BodyLong as="div" data-testid="ukjentArbeidsforhold">
                     <p>

--- a/apps/endringsmelding-pleiepenger/src/app/types/IngenTilgangÅrsak.ts
+++ b/apps/endringsmelding-pleiepenger/src/app/types/IngenTilgangÅrsak.ts
@@ -3,7 +3,7 @@ export enum IngenTilgangÅrsak {
     'harIngenSak' = 'harIngenSak',
     'harMerEnnEnSak' = 'harMerEnnEnSak',
     'harIngenPerioder' = 'harIngenPerioder',
-    'harArbeidsgiverSomIkkeErISak' = 'harArbeidsgiverSomIkkeErISak',
-    'harUkjentArbeidsforhold' = 'harUkjentArbeidsforhold',
+    'harArbeidsgiverUtenArbeidsaktivitet' = 'harArbeidsgiverUtenArbeidsaktivitet',
+    'harArbeidsaktivitetUtenArbeidsgiver' = 'harArbeidsaktivitetUtenArbeidsgiver',
     'harArbeidstidSomSelvstendigNæringsdrivende' = 'harArbeidstidSomSelvstendigNæringsdrivende',
 }

--- a/apps/endringsmelding-pleiepenger/src/app/utils/__tests__/tilgangskontroll.test.ts
+++ b/apps/endringsmelding-pleiepenger/src/app/utils/__tests__/tilgangskontroll.test.ts
@@ -9,7 +9,6 @@ const arbeidsgiver3: Arbeidsgiver = { organisasjonsnummer: '3' } as Arbeidsgiver
 
 const arbeidstaker1: K9SakArbeidstaker = { organisasjonsnummer: '1' } as K9SakArbeidstaker;
 const arbeidstaker2: K9SakArbeidstaker = { organisasjonsnummer: '2' } as K9SakArbeidstaker;
-// const arbeidstaker3: K9SakArbeidstaker = { organisasjonsnummer: '3' } as K9SakArbeidstaker;
 
 jest.mock('@navikt/sif-common-core-ds/lib/utils/envUtils', () => ({
     getEnvironmentVariable: () => {
@@ -26,7 +25,7 @@ describe('tilgangskontroll', () => {
         const result = tilgangskontroll([true, false] as any, []);
         expect(result.kanBrukeSøknad).toBeFalsy();
     });
-    it('stopper hvis bruker har arbeidgiver som ikke er i sak', () => {
+    it('stopper hvis bruker har arbeidsgiver som ikke er i sak', () => {
         const sak: K9Sak = {
             ytelse: {
                 arbeidstid: {
@@ -44,7 +43,7 @@ describe('tilgangskontroll', () => {
             expect(result.årsak).toEqual(IngenTilgangÅrsak.harArbeidsgiverUtenArbeidsaktivitet);
         }
     });
-    it('stopper hvis det er arbeidsaktiviteter i sak som ikke har arbeidsforhold ', () => {
+    it('stopper hvis det er arbeidsaktivitet i sak som ikke har arbeidsgiver', () => {
         const sak: K9Sak = {
             ytelse: {
                 arbeidstid: {
@@ -69,14 +68,14 @@ describe('tilgangskontroll', () => {
 
 describe('harArbeidsgiverUtenArbeidstakerK9Sak', () => {
     it('returnerer true dersom arbeidsgiver ikke har arbeidsaktivitet i sak', () => {
-        const result = tilgangskontrollUtils.harArbeidsgiverUtenArbeidstakerK9Sak(
+        const result = tilgangskontrollUtils.harArbeidsgiverUtenArbeidsaktivitet(
             [arbeidsgiver3],
             [arbeidstaker1, arbeidstaker2]
         );
         expect(result).toBeTruthy();
     });
     it('returnerer false dersom alle arbeidsgivere har arbeidsaktivitet i sak', () => {
-        const result = tilgangskontrollUtils.harArbeidsgiverUtenArbeidstakerK9Sak(
+        const result = tilgangskontrollUtils.harArbeidsgiverUtenArbeidsaktivitet(
             [arbeidsgiver1, arbeidsgiver2],
             [arbeidstaker1, arbeidstaker2]
         );
@@ -85,14 +84,14 @@ describe('harArbeidsgiverUtenArbeidstakerK9Sak', () => {
 });
 describe('harArbeidstakerISakUtenArbeidsforhold', () => {
     it('returnerer true dersom har har arbeidsaktivitet i sak med ikke tilhørende arbeidsgiver', () => {
-        const result = tilgangskontrollUtils.harArbeidstakerISakUtenArbeidsforhold(
+        const result = tilgangskontrollUtils.harArbeidsaktivitetUtenArbeidsgiver(
             [arbeidstaker1, arbeidstaker2],
             [arbeidsgiver3]
         );
         expect(result).toBeTruthy();
     });
     it('returnerer false dersom alle arbeidsaktiviteter i sak har tilhørende arbeidsgiver', () => {
-        const result = tilgangskontrollUtils.harArbeidstakerISakUtenArbeidsforhold(
+        const result = tilgangskontrollUtils.harArbeidsaktivitetUtenArbeidsgiver(
             [arbeidstaker1, arbeidstaker2],
             [arbeidsgiver1, arbeidsgiver2]
         );

--- a/apps/endringsmelding-pleiepenger/src/app/utils/__tests__/tilgangskontroll.test.ts
+++ b/apps/endringsmelding-pleiepenger/src/app/utils/__tests__/tilgangskontroll.test.ts
@@ -1,0 +1,101 @@
+import { Arbeidsgiver } from '../../types/Arbeidsgiver';
+import { IngenTilgangÅrsak } from '../../types/IngenTilgangÅrsak';
+import { K9Sak, K9SakArbeidstaker } from '../../types/K9Sak';
+import { tilgangskontroll, tilgangskontrollUtils } from '../tilgangskontroll';
+
+const arbeidsgiver1: Arbeidsgiver = { organisasjonsnummer: '1' } as Arbeidsgiver;
+const arbeidsgiver2: Arbeidsgiver = { organisasjonsnummer: '2' } as Arbeidsgiver;
+const arbeidsgiver3: Arbeidsgiver = { organisasjonsnummer: '3' } as Arbeidsgiver;
+
+const arbeidstaker1: K9SakArbeidstaker = { organisasjonsnummer: '1' } as K9SakArbeidstaker;
+const arbeidstaker2: K9SakArbeidstaker = { organisasjonsnummer: '2' } as K9SakArbeidstaker;
+// const arbeidstaker3: K9SakArbeidstaker = { organisasjonsnummer: '3' } as K9SakArbeidstaker;
+
+jest.mock('@navikt/sif-common-core-ds/lib/utils/envUtils', () => ({
+    getEnvironmentVariable: () => {
+        return false;
+    },
+}));
+
+describe('tilgangskontroll', () => {
+    it('stopper ved ingen sak', () => {
+        const result = tilgangskontroll([], []);
+        expect(result.kanBrukeSøknad).toBeFalsy();
+    });
+    it('stopper hvis bruker har flere enn én sak', () => {
+        const result = tilgangskontroll([true, false] as any, []);
+        expect(result.kanBrukeSøknad).toBeFalsy();
+    });
+    it('stopper hvis bruker har arbeidgiver som ikke er i sak', () => {
+        const sak: K9Sak = {
+            ytelse: {
+                arbeidstid: {
+                    arbeidstakerList: [
+                        {
+                            organisasjonsnummer: '2',
+                        },
+                    ],
+                },
+            },
+        } as K9Sak;
+        const result = tilgangskontroll([sak], [arbeidsgiver1]);
+        expect(result.kanBrukeSøknad).toBeFalsy();
+        if (result.kanBrukeSøknad === false) {
+            expect(result.årsak).toEqual(IngenTilgangÅrsak.harArbeidsgiverUtenArbeidsaktivitet);
+        }
+    });
+    it('stopper hvis det er arbeidsaktiviteter i sak som ikke har arbeidsforhold ', () => {
+        const sak: K9Sak = {
+            ytelse: {
+                arbeidstid: {
+                    arbeidstakerList: [
+                        {
+                            organisasjonsnummer: '1',
+                        },
+                        {
+                            organisasjonsnummer: '3',
+                        },
+                    ],
+                },
+            },
+        } as K9Sak;
+        const result = tilgangskontroll([sak], [arbeidsgiver1]);
+        expect(result.kanBrukeSøknad).toBeFalsy();
+        if (result.kanBrukeSøknad === false) {
+            expect(result.årsak).toEqual(IngenTilgangÅrsak.harArbeidsaktivitetUtenArbeidsgiver);
+        }
+    });
+});
+
+describe('harArbeidsgiverUtenArbeidstakerK9Sak', () => {
+    it('returnerer true dersom arbeidsgiver ikke har arbeidsaktivitet i sak', () => {
+        const result = tilgangskontrollUtils.harArbeidsgiverUtenArbeidstakerK9Sak(
+            [arbeidsgiver3],
+            [arbeidstaker1, arbeidstaker2]
+        );
+        expect(result).toBeTruthy();
+    });
+    it('returnerer false dersom alle arbeidsgivere har arbeidsaktivitet i sak', () => {
+        const result = tilgangskontrollUtils.harArbeidsgiverUtenArbeidstakerK9Sak(
+            [arbeidsgiver1, arbeidsgiver2],
+            [arbeidstaker1, arbeidstaker2]
+        );
+        expect(result).toBeFalsy();
+    });
+});
+describe('harArbeidstakerISakUtenArbeidsforhold', () => {
+    it('returnerer true dersom har har arbeidsaktivitet i sak med ikke tilhørende arbeidsgiver', () => {
+        const result = tilgangskontrollUtils.harArbeidstakerISakUtenArbeidsforhold(
+            [arbeidstaker1, arbeidstaker2],
+            [arbeidsgiver3]
+        );
+        expect(result).toBeTruthy();
+    });
+    it('returnerer false dersom alle arbeidsaktiviteter i sak har tilhørende arbeidsgiver', () => {
+        const result = tilgangskontrollUtils.harArbeidstakerISakUtenArbeidsforhold(
+            [arbeidstaker1, arbeidstaker2],
+            [arbeidsgiver1, arbeidsgiver2]
+        );
+        expect(result).toBeFalsy();
+    });
+});

--- a/apps/endringsmelding-pleiepenger/src/app/utils/tilgangskontroll.ts
+++ b/apps/endringsmelding-pleiepenger/src/app/utils/tilgangskontroll.ts
@@ -65,7 +65,7 @@ const harArbeidsgiverUtenArbeidsaktivitet = (
     arbeidsaktiviteter: K9SakArbeidstaker[] = []
 ): boolean => {
     return arbeidsgivere.some((arbeidsgiver) => {
-        return erArbeidsgiverISak(arbeidsgiver, arbeidsaktiviteter) === false;
+        return finnesArbeidsgiverISak(arbeidsgiver, arbeidsaktiviteter) === false;
     });
 };
 
@@ -78,11 +78,7 @@ const harArbeidsaktivitetUtenArbeidsgiver = (
         .some((id) => arbeidsgivere.some((aISak) => aISak.organisasjonsnummer === id) === false);
 };
 
-const getArbeidsaktivitetId = (arbeidsaktivitet: K9SakArbeidstaker): string => {
-    return arbeidsaktivitet.norskIdentitetsnummer || arbeidsaktivitet.organisasjonsnummer;
-};
-
-const erArbeidsgiverISak = (arbeidsgiver: Arbeidsgiver, arbeidsgivereISak: K9SakArbeidstaker[]): boolean => {
+const finnesArbeidsgiverISak = (arbeidsgiver: Arbeidsgiver, arbeidsgivereISak: K9SakArbeidstaker[]): boolean => {
     return arbeidsgivereISak.map(getArbeidsaktivitetId).some((id) => id === arbeidsgiver.organisasjonsnummer);
 };
 
@@ -90,7 +86,12 @@ const harArbeidstidSomSelvstendigNæringsdrivende = (sak: K9Sak) => {
     const { selvstendigNæringsdrivendeArbeidstidInfo: sn } = sak.ytelse.arbeidstid;
     return sn !== undefined && sn.perioder && Object.keys(sn.perioder).length > 0;
 };
+
+const getArbeidsaktivitetId = (arbeidsaktivitet: K9SakArbeidstaker): string => {
+    return arbeidsaktivitet.norskIdentitetsnummer || arbeidsaktivitet.organisasjonsnummer;
+};
+
 export const tilgangskontrollUtils = {
-    harArbeidsgiverUtenArbeidstakerK9Sak: harArbeidsgiverUtenArbeidsaktivitet,
-    harArbeidstakerISakUtenArbeidsforhold: harArbeidsaktivitetUtenArbeidsgiver,
+    harArbeidsgiverUtenArbeidsaktivitet,
+    harArbeidsaktivitetUtenArbeidsgiver,
 };

--- a/apps/endringsmelding-pleiepenger/src/app/utils/tilgangskontroll.ts
+++ b/apps/endringsmelding-pleiepenger/src/app/utils/tilgangskontroll.ts
@@ -73,9 +73,9 @@ const harArbeidsaktivitetUtenArbeidsgiver = (
     arbeidsaktiviteter: K9SakArbeidstaker[] = [],
     arbeidsgivere: Arbeidsgiver[]
 ) => {
-    return arbeidsaktiviteter.some(
-        (a) => arbeidsgivere.some((aISak) => aISak.organisasjonsnummer === a.organisasjonsnummer) === false
-    );
+    return arbeidsaktiviteter
+        .map(getArbeidsaktivitetId)
+        .some((id) => arbeidsgivere.some((aISak) => aISak.organisasjonsnummer === id) === false);
 };
 
 const getArbeidsaktivitetId = (arbeidsaktivitet: K9SakArbeidstaker): string => {


### PR DESCRIPTION
Mismatch mellom arbeidsgivere i sak og registrerte arbeidsgivere, og motsatt, ble logget som samme årsak i amplitude. 