### PR TITLE
Endre oppsett for kjøring av cypress-tester

### DIFF
--- a/.github/workflows/dispatch.deploy-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn-to-prod.yml
+++ b/.github/workflows/dispatch.deploy-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn-to-prod.yml
@@ -29,15 +29,21 @@ jobs:
             - name: Run code tests
               run: yarn test --filter=ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4.2.2 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   DEKORATOR_URL: https://www.nav.no/dekoratoren/?simple=true&chatbot=false
                   PUBLIC_PATH: /familie/sykdom-i-familien/soknad/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
               with:
                   project: ./apps/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn/e2e
                   build: yarn build-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
-                  start: yarn e2e-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
+                  start: yarn turbo start-e2e-server --filter=ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
 
     deploy-to-prod:
         name: Deploy ekstra-omsorgsdager-andre-forelder-ikke-tilsyn to prod

--- a/.github/workflows/dispatch.deploy-endringsmelding-pleiepenger-to-prod.yml
+++ b/.github/workflows/dispatch.deploy-endringsmelding-pleiepenger-to-prod.yml
@@ -29,8 +29,8 @@ jobs:
             - name: Run code tests
               run: yarn test --filter=endringsmelding-pleiepenger
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4.2.2 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   API_URL_INNSYN: http://localhost:8099
                   API_URL: http://localhost:8099
@@ -45,7 +45,13 @@ jobs:
               with:
                   project: ./apps/endringsmelding-pleiepenger/e2e
                   build: yarn build-endringsmelding-pleiepenger
-                  start: yarn e2e-endringsmelding-pleiepenger
+                  start: yarn turbo start-e2e-server --filter=endringsmelding-pleiepenger
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=endringsmelding-pleiepenger
 
     deploy-to-prod:
         name: Deploy endringsmelding-pleiepenger to prod

--- a/.github/workflows/dispatch.deploy-ettersending-to-prod.yml
+++ b/.github/workflows/dispatch.deploy-ettersending-to-prod.yml
@@ -29,11 +29,10 @@ jobs:
             - name: Run code tests
               run: yarn test --filter=sif-ettersending
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4.2.2 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   API_URL: http://localhost:8089/
-                  VEDLEGG_API_URL: http://localhost:8089/
                   FRONTEND_API_PATH: http://localhost:8089/
                   FRONTEND_VEDLEGG_URL: https://k9-ettersending-soknad.intern.dev.nav.no/api
                   LIVETS_SLUTTFASE: on
@@ -42,8 +41,13 @@ jobs:
               with:
                   project: ./apps/sif-ettersending/e2e
                   build: yarn build-sif-ettersending
-                  start: yarn e2e-sif-ettersending
-                  record: false
+                  start: yarn turbo start-e2e-server --filter=@navikt/sif-ettersending
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=@navikt/sif-ettersending
 
     deploy-to-prod:
         name: Deploy sif-ettersending to prod

--- a/.github/workflows/dispatch.deploy-ettersending-to-prod.yml
+++ b/.github/workflows/dispatch.deploy-ettersending-to-prod.yml
@@ -41,13 +41,13 @@ jobs:
               with:
                   project: ./apps/sif-ettersending/e2e
                   build: yarn build-sif-ettersending
-                  start: yarn turbo start-e2e-server --filter=@navikt/sif-ettersending
+                  start: yarn turbo start-e2e-server --filter=sif-ettersending
                   wait-on: 'http://localhost:8080'
                   wait-on-timeout: 60
                   runTests: false
 
             - name: Run cypress tests
-              run: yarn turbo cypress-run --filter=@navikt/sif-ettersending
+              run: yarn turbo cypress-run --filter=sif-ettersending
 
     deploy-to-prod:
         name: Deploy sif-ettersending to prod

--- a/.github/workflows/dispatch.deploy-omsorgsdager-aleneomsorg-dialog-to-prod.yml
+++ b/.github/workflows/dispatch.deploy-omsorgsdager-aleneomsorg-dialog-to-prod.yml
@@ -29,15 +29,21 @@ jobs:
             - name: Run code tests
               run: yarn test --filter=omsorgsdager-aleneomsorg-dialog
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4.2.2 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   DEKORATOR_URL: https://www.nav.no/dekoratoren/?simple=true&chatbot=false
                   PUBLIC_PATH: /familie/sykdom-i-familien/soknad/omsorgsdager-aleneomsorg
               with:
                   project: ./apps/omsorgsdager-aleneomsorg-dialog/e2e
                   build: yarn build-omsorgsdager-aleneomsorg-dialog
-                  start: yarn e2e-omsorgsdager-aleneomsorg-dialog
+                  start: yarn turbo start-e2e-server --filter=omsorgsdager-aleneomsorg-dialog
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=omsorgsdager-aleneomsorg-dialog
 
     deploy-to-prod:
         name: Deploy omsorgsdager-aleneomsorg-dialog to prod

--- a/.github/workflows/dispatch.deploy-omsorgspengesøknad-to-prod.yml
+++ b/.github/workflows/dispatch.deploy-omsorgspengesøknad-to-prod.yml
@@ -29,15 +29,21 @@ jobs:
             - name: Run code tests
               run: yarn test --filter=omsorgspengesoknad
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4.2.2 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   DEKORATOR_URL: https://www.nav.no/dekoratoren/?simple=true&chatbot=false
                   PUBLIC_PATH: /familie/sykdom-i-familien/soknad/omsorgspenger
               with:
                   project: ./apps/omsorgspengesoknad/e2e
                   build: yarn build-omsorgspengesoknad
-                  start: yarn e2e-omsorgspengesoknad
+                  start: yarn turbo start-e2e-server --filter=omsorgspengesoknad
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=omsorgspengesoknad
 
     deploy-to-prod:
         name: Deploy omsorgspengesøknad to prod

--- a/.github/workflows/test.ekstra-omsorgsdager-andre-forelder-ikke-tilsyn.yml
+++ b/.github/workflows/test.ekstra-omsorgsdager-andre-forelder-ikke-tilsyn.yml
@@ -7,6 +7,7 @@ on:
             - 'nais-config/**/*'
             - 'packages/**/*'
             - .github/workflows/app.ekstra-omsorgsdager-andre-forelder-ikke-tilsyn.yml
+            - .github/workflows/test.ekstra-omsorgsdager-andre-forelder-ikke-tilsyn.yml
 
 env:
     APP_NAME: 'ekstra-omsorgsdager-andre-forelder-ikke-tilsyn'

--- a/.github/workflows/test.ekstra-omsorgsdager-andre-forelder-ikke-tilsyn.yml
+++ b/.github/workflows/test.ekstra-omsorgsdager-andre-forelder-ikke-tilsyn.yml
@@ -42,18 +42,21 @@ jobs:
                   node-version: 16
                   cache: 'yarn'
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   DEKORATOR_URL: https://www.nav.no/dekoratoren/?simple=true&chatbot=false
                   PUBLIC_PATH: /familie/sykdom-i-familien/soknad/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
                   FRONTEND_API_PATH: http://localhost:8089/
-                  # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
-                  # in GitHub repo → Settings → Secrets → Actions
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   project: ./apps/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn/e2e
                   build: yarn build-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
-                  start: yarn e2e-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
+                  start: yarn turbo start-e2e-server --filter=ekstra-omsorgsdager-andre-forelder-ikke-tilsyn
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=ekstra-omsorgsdager-andre-forelder-ikke-tilsyn

--- a/.github/workflows/test.endringsmelding-pleiepenger.yml
+++ b/.github/workflows/test.endringsmelding-pleiepenger.yml
@@ -44,8 +44,8 @@ jobs:
                   node-version: 16
                   cache: 'yarn'
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   API_URL_INNSYN: http://localhost:8099
                   API_URL: http://localhost:8099
@@ -57,12 +57,15 @@ jobs:
                   FRONTEND_VEDLEGG_URL: http://localhost:8099/api
                   FRONTEND_INNSYN_API_PATH: http://localhost:8099/api
                   VELG_SAK: off
-                  # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
-                  # in GitHub repo → Settings → Secrets → Actions
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   project: ./apps/endringsmelding-pleiepenger/e2e
                   build: yarn build-endringsmelding-pleiepenger
-                  start: yarn e2e-endringsmelding-pleiepenger
+                  start: yarn turbo start-e2e-server --filter=endringsmelding-pleiepenger
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=endringsmelding-pleiepenger

--- a/.github/workflows/test.endringsmelding-pleiepenger.yml
+++ b/.github/workflows/test.endringsmelding-pleiepenger.yml
@@ -9,6 +9,7 @@ on:
             - 'nais-config/**/*'
             - 'packages/**/*'
             - .github/workflows/app.endringsmelding-pleiepenger.yml
+            - .github/workflows/test.endringsmelding-pleiepenger.yml
 
 env:
     APP_NAME: 'endringsmelding-pleiepenger'

--- a/.github/workflows/test.omsorgsdager-aleneomsorg-dialog.yml
+++ b/.github/workflows/test.omsorgsdager-aleneomsorg-dialog.yml
@@ -42,18 +42,21 @@ jobs:
                   node-version: 16
                   cache: 'yarn'
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   DEKORATOR_URL: https://www.nav.no/dekoratoren/?simple=true&chatbot=false
                   PUBLIC_PATH: /familie/sykdom-i-familien/soknad/omsorgsdager-aleneomsorg
                   FRONTEND_API_PATH: http://localhost:8089/
-                  # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
-                  # in GitHub repo → Settings → Secrets → Actions
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   project: ./apps/omsorgsdager-aleneomsorg-dialog/e2e
                   build: yarn build-omsorgsdager-aleneomsorg-dialog
-                  start: yarn e2e-omsorgsdager-aleneomsorg-dialog
+                  start: yarn turbo start-e2e-server --filter=omsorgsdager-aleneomsorg-dialog
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=omsorgsdager-aleneomsorg-dialog

--- a/.github/workflows/test.omsorgsdager-aleneomsorg-dialog.yml
+++ b/.github/workflows/test.omsorgsdager-aleneomsorg-dialog.yml
@@ -7,6 +7,7 @@ on:
             - 'nais-config/**/*'
             - 'packages/**/*'
             - .github/workflows/app.omsorgsdager-aleneomsorg-dialog.yml
+            - .github/workflows/test.omsorgsdager-aleneomsorg-dialog.yml
 
 env:
     APP_NAME: 'omsorgsdager-aleneomsorg-dialog'

--- a/.github/workflows/test.omsorgspengesøknad.yml
+++ b/.github/workflows/test.omsorgspengesøknad.yml
@@ -42,18 +42,21 @@ jobs:
                   node-version: 16
                   cache: 'yarn'
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4 # use the explicit version number
+            - name: Build and start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   DEKORATOR_URL: https://www.nav.no/dekoratoren/?simple=true&chatbot=false
                   PUBLIC_PATH: /familie/sykdom-i-familien/soknad/omsorgspenger
                   FRONTEND_API_PATH: http://localhost:8089/
-                  # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
-                  # in GitHub repo → Settings → Secrets → Actions
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   project: ./apps/omsorgspengesoknad/e2e
                   build: yarn build-omsorgspengesoknad
-                  start: yarn e2e-omsorgspengesoknad
+                  start: yarn turbo start-e2e-server --filter=omsorgspengesoknad
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=omsorgspengesoknad

--- a/.github/workflows/test.omsorgspengesøknad.yml
+++ b/.github/workflows/test.omsorgspengesøknad.yml
@@ -7,6 +7,7 @@ on:
             - 'nais-config/**/*'
             - 'packages/**/*'
             - .github/workflows/app.omsorgspengesøknad.yml
+            - .github/workflows/test.omsorgspengesøknad.yml
 
 env:
     APP_NAME: 'omsorgspengesoknad'

--- a/.github/workflows/test.sif-ettersending.yml
+++ b/.github/workflows/test.sif-ettersending.yml
@@ -42,7 +42,7 @@ jobs:
                   node-version: 16
                   cache: 'yarn'
 
-            - name: Start e2e server
+            - name: Build and start e2e server
               uses: cypress-io/github-action@v5
               env:
                   API_URL: http://localhost:8089/

--- a/.github/workflows/test.sif-ettersending.yml
+++ b/.github/workflows/test.sif-ettersending.yml
@@ -55,9 +55,9 @@ jobs:
               with:
                   project: ./apps/sif-ettersending/e2e
                   build: yarn build-sif-ettersending
-                  start: yarn turbo start-e2e-server --filter=@navikt/sif-ettersending
+                  start: yarn turbo start-e2e-server --filter=sif-ettersending
                   wait-on: 'http://localhost:8080'
                   wait-on-timeout: 60
                   runTests: false
             - name: Run cypress tests
-              run: yarn turbo cypress-run --filter=@navikt/sif-ettersending
+              run: yarn turbo cypress-run --filter=sif-ettersending

--- a/.github/workflows/test.sif-ettersending.yml
+++ b/.github/workflows/test.sif-ettersending.yml
@@ -42,8 +42,8 @@ jobs:
                   node-version: 16
                   cache: 'yarn'
 
-            - name: Run cypress tests
-              uses: cypress-io/github-action@v4.2.2 # use the explicit version number
+            - name: Start e2e server
+              uses: cypress-io/github-action@v5
               env:
                   API_URL: http://localhost:8089/
                   FRONTEND_API_PATH: http://localhost:8089/
@@ -54,5 +54,9 @@ jobs:
               with:
                   project: ./apps/sif-ettersending/e2e
                   build: yarn build-sif-ettersending
-                  start: yarn e2e-sif-ettersending
-                  record: false
+                  start: yarn turbo start-e2e-server --filter=@navikt/sif-ettersending
+                  wait-on: 'http://localhost:8080'
+                  wait-on-timeout: 60
+                  runTests: false
+            - name: Run cypress tests
+              run: yarn turbo cypress-run --filter=@navikt/sif-ettersending

--- a/.github/workflows/test.sif-ettersending.yml
+++ b/.github/workflows/test.sif-ettersending.yml
@@ -7,6 +7,7 @@ on:
             - 'nais-config/**/*'
             - 'packages/**/*'
             - .github/workflows/app.sif-ettersending.yml
+            - .github/workflows/test.sif-ettersending.yml
 
 env:
     APP_NAME: 'ettersending'

--- a/apps/sif-ettersending/package.json
+++ b/apps/sif-ettersending/package.json
@@ -94,8 +94,6 @@
     "scripts": {
         "build": "npm-run-all build-app",
         "build-app": "node src/build/scripts/production-build.js",
-        "ci": "start-server-and-test 'yarn start-e2e-server' http://localhost:8080/familie/sykdom-i-familien/soknad/ettersending/alive 'yarn cypress-run'",
-        "ci-server": "server-test http://localhost:8080/familie/sykdom-i-familien/soknad/ettersending/alive",
         "cypress": "cypress open --project $PWD/e2e",
         "cypress-run": "cypress run --project $PWD/e2e",
         "clean": "rm -rf node_modules .dist",

--- a/apps/sif-ettersending/package.json
+++ b/apps/sif-ettersending/package.json
@@ -94,7 +94,7 @@
     "scripts": {
         "build": "npm-run-all build-app",
         "build-app": "node src/build/scripts/production-build.js",
-        "cypress": "cypress open --project $PWD/e2e",
+        "cypress-open": "cypress open --project $PWD/e2e",
         "cypress-run": "cypress run --project $PWD/e2e",
         "clean": "rm -rf node_modules .dist",
         "dev-api": "PORT=8089 node ./server/api-mock.js",

--- a/turbo.json
+++ b/turbo.json
@@ -16,10 +16,6 @@
             "outputs": [],
             "dependsOn": ["^build-package"]
         },
-        "ci": {
-            "outputs": [],
-            "dependsOn": ["^build-package", "^build-app"]
-        },
         "test-watch": {
             "outputs": [],
             "dependsOn": ["^build-package"]
@@ -38,45 +34,32 @@
         "clean": {
             "cache": false
         },
+        "start-e2e-server": {
+            "outputs": []
+        },
+        "cypress-run": {
+            "outputs": [],
+            "dependsOn": ["^start-e2e-server", "^build-app"]
+        },
         "build-omsorgspengesoknad": {
             "outputs": [],
             "dependsOn": ["^build-package"]
-        },
-        "e2e-omsorgspengesoknad": {
-            "outputs": [],
-            "dependsOn": ["^build-omsorgspengesoknad"]
         },
         "build-sif-ettersending": {
             "outputs": [],
             "dependsOn": ["^build-package"]
         },
-        "e2e-sif-ettersending": {
-            "outputs": [],
-            "dependsOn": ["^build-sif-ettersending"]
-        },
         "build-endringsmelding-pleiepenger": {
             "outputs": [],
             "dependsOn": ["^build-package"]
-        },
-        "e2e-endringsmelding-pleiepenger": {
-            "outputs": [],
-            "dependsOn": ["^build-endringsmelding-pleiepenger"]
         },
         "build-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn": {
             "outputs": [],
             "dependsOn": ["^build-package"]
         },
-        "e2e-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn": {
-            "outputs": [],
-            "dependsOn": ["^build-ekstra-omsorgsdager-andre-forelder-ikke-tilsyn"]
-        },
         "build-omsorgsdager-aleneomsorg-dialog": {
             "outputs": [],
             "dependsOn": ["^build-package"]
-        },
-        "e2e-omsorgsdager-aleneomsorg-dialog": {
-            "outputs": [],
-            "dependsOn": ["^build-omsorgsdager-aleneomsorg-dialog"]
         }
     }
 }


### PR DESCRIPTION
Kjøring av tester gjøres nå i to steg, ett som setter opp og starter server, og ett som kjører testene. Ingen kodemessige eller funksjonelle endringer, så det er ikke behov for changeset.