### PR TITLE
Innsyn bugfix sort hendelser

### DIFF
--- a/.changeset/funny-students-end.md
+++ b/.changeset/funny-students-end.md
@@ -1,0 +1,5 @@
+---
+"@navikt/dine-pleiepenger": patch
+---
+
+Korrigere sortering av søknadshendelser slik at FORVENTET_SVAR alltid kommer sist, selv om det er kommet inn endring eller søknad etter at svarfrist er passert.

--- a/apps/dine-pleiepenger/api-mock-server/api-mock-server.js
+++ b/apps/dine-pleiepenger/api-mock-server/api-mock-server.js
@@ -4,12 +4,13 @@ const helmet = require('helmet');
 const server = express();
 const søknader = require('./mockdata/soknader.json');
 // const saker = require('./mockdata/saker-søknad-og-endring-ubehandlet.json');
-const saker = require('./mockdata/saker-med-to-vedtak.json');
+// const saker = require('./mockdata/saker-med-to-vedtak.json');
 // const saker = require('./mockdata/saker-uten-søknad-men-behandling.json');
 // const saker = require('./mockdata/sak-uten-behandling.json');
 // const saker = require('./mockdata/saker.json');
 // const saker = require('./mockdata/saker-sn.json');
 // const saker = require('./mockdata/saker-med-venteårsak.json');
+const saker = require('./mockdata/saker-debug.json');
 
 server.use(express.json());
 

--- a/apps/dine-pleiepenger/api-mock-server/mockdata/saker-debug.json
+++ b/apps/dine-pleiepenger/api-mock-server/mockdata/saker-debug.json
@@ -1,0 +1,218 @@
+[
+    {
+        "pleietrengende": {
+            "identitetsnummer": "21522057999",
+            "fødselsdato": "2020-12-21",
+            "fornavn": "GRÅ",
+            "mellomnavn": null,
+            "etternavn": "EKSPLOSJON",
+            "aktørId": "2426520634541"
+        },
+        "sak": {
+            "saksnummer": "1DQARL2",
+            "saksbehandlingsFrist": "2024-03-27",
+            "fagsakYtelseType": { "kode": "PSB", "kodeverk": "FAGSAK_YTELSE" },
+            "ytelseType": "PSB",
+            "behandlinger": [
+                {
+                    "status": "UNDER_BEHANDLING",
+                    "opprettetTidspunkt": "2024-02-14T11:30:09.000Z",
+                    "avsluttetTidspunkt": null,
+                    "søknader": [
+                        {
+                            "søknadId": "67bc44cb-bd73-4ba7-91b2-c069cf5abe8d",
+                            "søknadstype": "ENDRINGSMELDING",
+                            "k9FormatSøknad": {
+                                "søknadId": "67bc44cb-bd73-4ba7-91b2-c069cf5abe8d",
+                                "versjon": "1.0.0",
+                                "mottattDato": "2024-04-22T14:08:12.567Z",
+                                "søker": { "norskIdentitetsnummer": "26499327918" },
+                                "språk": null,
+                                "ytelse": {
+                                    "type": "PLEIEPENGER_SYKT_BARN",
+                                    "barn": { "norskIdentitetsnummer": "21522057999", "fødselsdato": "2020-12-21" },
+                                    "søknadsperiode": [],
+                                    "endringsperiode": [],
+                                    "trekkKravPerioder": [],
+                                    "opptjeningAktivitet": {},
+                                    "dataBruktTilUtledning": {
+                                        "harForståttRettigheterOgPlikter": null,
+                                        "harBekreftetOpplysninger": null,
+                                        "samtidigHjemme": null,
+                                        "harMedsøker": null,
+                                        "soknadDialogCommitSha": null,
+                                        "bekrefterPeriodeOver8Uker": null,
+                                        "ukjenteArbeidsforhold": []
+                                    },
+                                    "annetDataBruktTilUtledning": {
+                                        "harForståttRettigheterOgPlikter": null,
+                                        "harBekreftetOpplysninger": null,
+                                        "soknadDialogCommitSha": null,
+                                        "annetData": "{\"valgteEndringer\":{\"arbeidstid\":true,\"lovbestemtFerie\":false}}"
+                                    },
+                                    "infoFraPunsj": null,
+                                    "bosteder": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                                    "utenlandsopphold": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                                    "beredskap": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                                    "nattevåk": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                                    "tilsynsordning": { "perioder": {} },
+                                    "lovbestemtFerie": { "perioder": {} },
+                                    "arbeidstid": {
+                                        "arbeidstakerList": [
+                                            {
+                                                "norskIdentitetsnummer": null,
+                                                "organisasjonsnummer": "967170232",
+                                                "organisasjonsnavn": "SNILL TORPEDO",
+                                                "arbeidstidInfo": {
+                                                    "perioder": {
+                                                        "2024-03-18/2024-03-22": {
+                                                            "jobberNormaltTimerPerDag": "PT4H",
+                                                            "faktiskArbeidTimerPerDag": "PT2H"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "frilanserArbeidstidInfo": null,
+                                        "selvstendigNæringsdrivendeArbeidstidInfo": null
+                                    },
+                                    "uttak": { "perioder": {} },
+                                    "omsorg": { "relasjonTilBarnet": null, "beskrivelseAvOmsorgsrollen": null }
+                                },
+                                "journalposter": [],
+                                "begrunnelseForInnsending": { "tekst": null },
+                                "kildesystem": "endringsdialog"
+                            },
+                            "dokumenter": [
+                                {
+                                    "journalpostId": "637607202",
+                                    "dokumentInfoId": "667158670",
+                                    "saksnummer": "1DQARL2",
+                                    "tittel": "Endringsmelding for pleiepenger sykt barn",
+                                    "dokumentType": "PLEIEPENGER_SYKT_BARN_SOKNAD",
+                                    "filtype": "PDF",
+                                    "harTilgang": true,
+                                    "url": "http://sif-innsyn-api/dokument/637607202/667158670/ARKIV",
+                                    "relevanteDatoer": [
+                                        { "dato": "2024-04-22T16:08:15", "datotype": "DATO_OPPRETTET" },
+                                        { "dato": "2024-04-22T16:08:15", "datotype": "DATO_DOKUMENT" },
+                                        { "dato": "2024-04-22T16:08:21", "datotype": "DATO_JOURNALFOERT" },
+                                        { "dato": "2024-04-22T16:08:12", "datotype": "DATO_REGISTRERT" }
+                                    ]
+                                }
+                            ],
+                            "arbeidsgivere": [{ "organisasjonsnummer": "967170232", "navn": "SNILL TORPEDO" }]
+                        },
+                        {
+                            "søknadId": "c82e2cfa-e928-49c3-bd6b-cb88f36ce63b",
+                            "søknadstype": "SØKNAD",
+                            "k9FormatSøknad": {
+                                "søknadId": "c82e2cfa-e928-49c3-bd6b-cb88f36ce63b",
+                                "versjon": "1.0.0",
+                                "mottattDato": "2024-02-14T11:17:39.392Z",
+                                "søker": { "norskIdentitetsnummer": "26499327918" },
+                                "språk": "nb",
+                                "ytelse": {
+                                    "type": "PLEIEPENGER_SYKT_BARN",
+                                    "barn": { "norskIdentitetsnummer": "21522057999", "fødselsdato": null },
+                                    "søknadsperiode": ["2024-03-12/2024-03-22"],
+                                    "endringsperiode": [],
+                                    "trekkKravPerioder": [],
+                                    "opptjeningAktivitet": {},
+                                    "dataBruktTilUtledning": null,
+                                    "annetDataBruktTilUtledning": {
+                                        "harForståttRettigheterOgPlikter": true,
+                                        "harBekreftetOpplysninger": true,
+                                        "soknadDialogCommitSha": null,
+                                        "annetData": null
+                                    },
+                                    "infoFraPunsj": null,
+                                    "bosteder": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                                    "utenlandsopphold": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                                    "beredskap": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                                    "nattevåk": { "perioder": {}, "perioderSomSkalSlettes": {} },
+                                    "tilsynsordning": {
+                                        "perioder": { "2024-03-12/2024-03-22": { "etablertTilsynTimerPerDag": "PT0S" } }
+                                    },
+                                    "lovbestemtFerie": { "perioder": {} },
+                                    "arbeidstid": {
+                                        "arbeidstakerList": [
+                                            {
+                                                "norskIdentitetsnummer": null,
+                                                "organisasjonsnummer": "967170232",
+                                                "organisasjonsnavn": "SNILL TORPEDO",
+                                                "arbeidstidInfo": {
+                                                    "perioder": {
+                                                        "2024-03-12/2024-03-22": {
+                                                            "jobberNormaltTimerPerDag": "PT4H",
+                                                            "faktiskArbeidTimerPerDag": "PT0S"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "frilanserArbeidstidInfo": {
+                                            "perioder": {
+                                                "2024-03-12/2024-03-22": {
+                                                    "jobberNormaltTimerPerDag": "PT0S",
+                                                    "faktiskArbeidTimerPerDag": "PT0S"
+                                                }
+                                            }
+                                        },
+                                        "selvstendigNæringsdrivendeArbeidstidInfo": null
+                                    },
+                                    "uttak": {
+                                        "perioder": {
+                                            "2024-03-12/2024-03-22": { "timerPleieAvBarnetPerDag": "PT7H30M" }
+                                        }
+                                    },
+                                    "omsorg": { "relasjonTilBarnet": null, "beskrivelseAvOmsorgsrollen": null }
+                                },
+                                "journalposter": [],
+                                "begrunnelseForInnsending": { "tekst": null },
+                                "kildesystem": "søknadsdialog"
+                            },
+                            "dokumenter": [
+                                {
+                                    "journalpostId": "637581711",
+                                    "dokumentInfoId": "667124031",
+                                    "saksnummer": "1DQARL2",
+                                    "tittel": "Søknad om pleiepenger for sykt barn",
+                                    "dokumentType": "PLEIEPENGER_SYKT_BARN_SOKNAD",
+                                    "filtype": "PDF",
+                                    "harTilgang": true,
+                                    "url": "http://sif-innsyn-api/dokument/637581711/667124031/ARKIV",
+                                    "relevanteDatoer": [
+                                        { "dato": "2024-02-14T12:17:42", "datotype": "DATO_OPPRETTET" },
+                                        { "dato": "2024-02-14T12:17:42", "datotype": "DATO_DOKUMENT" },
+                                        { "dato": "2024-02-14T12:17:50", "datotype": "DATO_JOURNALFOERT" },
+                                        { "dato": "2024-02-14T12:17:39", "datotype": "DATO_REGISTRERT" }
+                                    ]
+                                },
+                                {
+                                    "journalpostId": "637581711",
+                                    "dokumentInfoId": "667124032",
+                                    "saksnummer": "1DQARL2",
+                                    "tittel": "Cladding_Siding_Tan2.jpg",
+                                    "dokumentType": "PLEIEPENGER_SYKT_BARN_SOKNAD",
+                                    "filtype": "PDF",
+                                    "harTilgang": true,
+                                    "url": "http://sif-innsyn-api/dokument/637581711/667124032/ARKIV",
+                                    "relevanteDatoer": [
+                                        { "dato": "2024-02-14T12:17:42", "datotype": "DATO_OPPRETTET" },
+                                        { "dato": "2024-02-14T12:17:42", "datotype": "DATO_DOKUMENT" },
+                                        { "dato": "2024-02-14T12:17:50", "datotype": "DATO_JOURNALFOERT" },
+                                        { "dato": "2024-02-14T12:17:39", "datotype": "DATO_REGISTRERT" }
+                                    ]
+                                }
+                            ],
+                            "arbeidsgivere": [{ "organisasjonsnummer": "967170232", "navn": "SNILL TORPEDO" }]
+                        }
+                    ],
+                    "aksjonspunkter": [],
+                    "utgåendeDokumenter": []
+                }
+            ]
+        }
+    }
+]

--- a/apps/dine-pleiepenger/src/utils/__tests__/sakUtils.test.ts
+++ b/apps/dine-pleiepenger/src/utils/__tests__/sakUtils.test.ts
@@ -1,8 +1,10 @@
 import { ISODateToDate } from '@navikt/sif-common-utils';
 import { Behandling } from '../../server/api-models/BehandlingSchema';
 import { Behandlingsstatus } from '../../server/api-models/Behandlingsstatus';
-import { getSisteBehandlingISak, sortBehandlingerNyesteFørst } from '../sakUtils';
+import { getSisteBehandlingISak, sortBehandlingerNyesteFørst, sortSøknadshendelse } from '../sakUtils';
 import { Sak } from '../../server/api-models/SakSchema';
+import { Søknadshendelse, SøknadshendelseType } from '../../types/Søknadshendelse';
+import { Søknadstype } from '../../server/api-models/Søknadstype';
 
 const behandling1: Behandling = {
     status: Behandlingsstatus.UNDER_BEHANDLING,
@@ -42,6 +44,37 @@ describe('sakUtils', () => {
             };
             const sisteBehandling = getSisteBehandlingISak(sak);
             expect(sisteBehandling).toEqual(behandling2);
+        });
+    });
+
+    describe('sortSøknadshendelse', () => {
+        const hendelse1: Søknadshendelse = {
+            dato: ISODateToDate('2020-01-01'),
+            type: SøknadshendelseType.FERDIG_BEHANDLET,
+        };
+        const hendelse2: Søknadshendelse = {
+            dato: ISODateToDate('2020-01-03'),
+            type: SøknadshendelseType.MOTTATT_SØKNAD,
+            søknad: {} as any,
+        };
+        const hendelse3: Søknadshendelse = {
+            dato: ISODateToDate('2020-01-03'),
+            type: SøknadshendelseType.FERDIG_BEHANDLET,
+        };
+
+        const hendelseForventetSvar: Søknadshendelse = {
+            dato: ISODateToDate('2020-01-02'),
+            type: SøknadshendelseType.FORVENTET_SVAR,
+            søknadstyperIBehandling: [Søknadstype.SØKNAD],
+        };
+
+        it('sorterer riktig på hendelser som ikke er FORVENTET_SVAR', () => {
+            const result = [hendelse1, hendelse2, hendelse3].sort(sortSøknadshendelse);
+            expect(result).toEqual([hendelse1, hendelse3, hendelse2]);
+        });
+        it('sorterer alltid FORVENTET_SVAR sist', () => {
+            const result = [hendelseForventetSvar, hendelse1, hendelse2, hendelse3].sort(sortSøknadshendelse);
+            expect(result).toEqual([hendelse1, hendelse3, hendelse2, hendelseForventetSvar]);
         });
     });
 });

--- a/apps/dine-pleiepenger/src/utils/sakUtils.ts
+++ b/apps/dine-pleiepenger/src/utils/sakUtils.ts
@@ -43,8 +43,13 @@ export const sortSøknader = (søknader: Søknad[]): Søknad[] => {
     return sortBy(søknader, ({ k9FormatSøknad }: Søknad) => k9FormatSøknad.mottattDato.getTime()).reverse();
 };
 
-export const sortSøknadshendelser = (hendelser: Søknadshendelse[]): Søknadshendelse[] => {
-    return sortBy(hendelser, ({ dato }: Søknadshendelse) => dato?.getTime());
+export const sortSøknadshendelse = (h1: Søknadshendelse, h2: Søknadshendelse): number => {
+    if (h1.type === SøknadshendelseType.FORVENTET_SVAR) {
+        return 1;
+    } else if (h2.type === SøknadshendelseType.FORVENTET_SVAR) {
+        return -1;
+    }
+    return (h1.dato?.getTime() || 0) > (h2.dato?.getTime() || 0) ? 1 : -1;
 };
 
 export const getBehandlingsstatusISak = (sak: Sak): BehandlingsstatusISak | undefined => {
@@ -112,9 +117,10 @@ export const getSøknadstyperIBehandling = (søknader: Søknad[]): Array<Søknad
 };
 
 export const getAlleHendelserISak = (sak: Sak): Søknadshendelse[] => {
-    return sortSøknadshendelser(
-        sak.behandlinger.map((b) => getHendelserIBehandling(b, sak.saksbehandlingsFrist)).flat(),
-    );
+    const søknadshendelser: Søknadshendelse[] = sak.behandlinger
+        .map((b) => getHendelserIBehandling(b, sak.saksbehandlingsFrist))
+        .flat();
+    return søknadshendelser.sort(sortSøknadshendelse);
 };
 
 export const getViktigsteVenteårsakForAksjonspunkter = (aksjonspunkter: Aksjonspunkt[]): Venteårsak => {


### PR DESCRIPTION
Sortering i tidslinjen ble feil dersom det var en åpen behandling hvor svarfristen var passert. Da kom ikke FORVENTET_SVAR hendelsen sist.