### PR TITLE
Forbedring av delt bosted-dialogen

### DIFF
--- a/.changeset/blue-guests-remember.md
+++ b/.changeset/blue-guests-remember.md
@@ -1,0 +1,5 @@
+---
+'@navikt/omsorgsdager-aleneomsorg-dialog': patch
+---
+
+Forenklet søknaden ved å fjerne spørsmål om hvilke barn man har avtale om delt fast bosted med

--- a/apps/omsorgsdager-aleneomsorg-dialog/e2e/playwright/tests/fylle-ut-full-søknad-nytt-barn.spec.ts
+++ b/apps/omsorgsdager-aleneomsorg-dialog/e2e/playwright/tests/fylle-ut-full-søknad-nytt-barn.spec.ts
@@ -26,16 +26,11 @@ test('Fyll ut full søknad nytt barn', async ({ page }) => {
     await page.getByLabel('Barnets fødselsnummer/D-nummer').fill('09847696068');
     await page.getByLabel('Barnet er mitt fosterbarn').check();
     await page.getByLabel('Legg til barn').getByTestId('typedFormikForm-submitButton').click();
-    await page.getByLabel('Nei').check();
-    await page.getByLabel('Ja').check();
     await page
         .getByRole('group', { name: 'Kryss av for barn du er alene om omsorgen for:' })
         .getByLabel('Født 10.10.2020 Nytt Barn')
         .check();
-    await page
-        .getByRole('group', { name: 'Kryss av for hvilke barn du har delt fast bosted for:' })
-        .getByLabel('Født 20.04.2020 Barn Barnesen')
-        .check();
+    await page.getByLabel('Nei').check();
     await page.getByRole('button', { name: 'Neste' }).click();
 
     await page.getByRole('heading', { level: 1, name: 'Tidspunkt for aleneomsorg' });

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/OmOmsorgenForBarnStep.tsx
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/OmOmsorgenForBarnStep.tsx
@@ -133,6 +133,7 @@ const OmOmsorgenForBarnStep = () => {
                     const harAleneomsorgForOptions = getBarnOptions(registrertBarn, annetBarn).filter((option) =>
                         harAleneomsorgFor.includes(option.value),
                     );
+                    const visVelgMinstEttBarnMedDeltBostedAdvarsel = harAleneomsorgForOptions.length === 0;
 
                     const kanIkkeFortsette =
                         !harBarn || alleBarnMedDeltBosted || ettBarnOgDeltBosted || barnMedDeltBostedHarAleneomsorg;
@@ -244,12 +245,20 @@ const OmOmsorgenForBarnStep = () => {
 
                                             {visDeltBostedBarnValg && (
                                                 <Block margin="xl">
-                                                    <CheckboxGroup
-                                                        legend={text('steg.omOmsorgenForBarn.deltBosted')}
-                                                        name={OmOmsorgenForBarnFormFields.harAvtaleOmDeltBostedFor}
-                                                        checkboxes={harAleneomsorgForOptions}
-                                                        validate={getListValidator({ required: true })}
-                                                    />
+                                                    {visVelgMinstEttBarnMedDeltBostedAdvarsel ? (
+                                                        <Alert variant="warning">
+                                                            {text(
+                                                                'steg.omOmsorgenForBarna.deltBosted.velgMinstEttBarnMedDeltBostedAdvarsel',
+                                                            )}
+                                                        </Alert>
+                                                    ) : (
+                                                        <CheckboxGroup
+                                                            legend={text('steg.omOmsorgenForBarn.deltBosted')}
+                                                            name={OmOmsorgenForBarnFormFields.harAvtaleOmDeltBostedFor}
+                                                            checkboxes={harAleneomsorgForOptions}
+                                                            validate={getListValidator({ required: true })}
+                                                        />
+                                                    )}
                                                 </Block>
                                             )}
                                         </Block>

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/OmOmsorgenForBarnStep.tsx
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/OmOmsorgenForBarnStep.tsx
@@ -129,6 +129,11 @@ const OmOmsorgenForBarnStep = () => {
                             setFieldValue(OmOmsorgenForBarnFormFields.harAvtaleOmDeltBostedFor, []);
                         }
                     };
+
+                    const harAleneomsorgForOptions = getBarnOptions(registrertBarn, annetBarn).filter((option) =>
+                        harAleneomsorgFor.includes(option.value),
+                    );
+
                     const kanIkkeFortsette =
                         !harBarn || alleBarnMedDeltBosted || ettBarnOgDeltBosted || barnMedDeltBostedHarAleneomsorg;
                     return (
@@ -242,7 +247,7 @@ const OmOmsorgenForBarnStep = () => {
                                                     <CheckboxGroup
                                                         legend={text('steg.omOmsorgenForBarn.deltBosted')}
                                                         name={OmOmsorgenForBarnFormFields.harAvtaleOmDeltBostedFor}
-                                                        checkboxes={getBarnOptions(registrertBarn, annetBarn)}
+                                                        checkboxes={harAleneomsorgForOptions}
                                                         validate={getListValidator({ required: true })}
                                                     />
                                                 </Block>

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/OmOmsorgenForBarnStep.tsx
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/OmOmsorgenForBarnStep.tsx
@@ -90,43 +90,35 @@ const OmOmsorgenForBarnStep = () => {
                 initialValues={getOmOmsorgenForBarnStepInitialValues(søknadsdata, stepFormValues[stepId])}
                 onSubmit={handleSubmit}
                 renderForm={({
-                    values: { annetBarn = [], harAvtaleOmDeltBostedFor, avtaleOmDeltBosted, harAleneomsorgFor = [] },
+                    values: { annetBarn = [], avtaleOmDeltBosted, harAleneomsorgFor = [] },
                     setFieldValue,
                 }) => {
                     const alleBarn = [...registrertBarn, ...annetBarn];
-                    const barnManHarAleneomsorgFor = alleBarn.filter((barn) =>
-                        harAleneomsorgFor.includes('fnr' in barn ? barn.fnr : barn.aktørId),
-                    );
                     const antallBarn = alleBarn.length;
-                    const antallBarnManHarAleneomsorgFor = barnManHarAleneomsorgFor.length;
+                    const antallBarnManHarAleneomsorgFor = harAleneomsorgFor.length;
 
                     const harBarn = antallBarn > 0;
-                    const harFlereBarn = antallBarn > 1;
 
-                    const harAvtaleOmDeltBosted = avtaleOmDeltBosted === YesOrNo.YES;
-                    const harAleneomsorgForNoenBarn = antallBarnManHarAleneomsorgFor > 0;
                     const harIkkeAleneomsorgForNoenBarn = antallBarnManHarAleneomsorgFor === 0;
                     const harAleneomsorgForNøyaktigEttBarn = antallBarnManHarAleneomsorgFor === 1;
-                    const harAleneomsorgForFlereBarn = antallBarnManHarAleneomsorgFor > 1;
-                    const harAvtaleOmDeltBostedForNoenBarnManHarAleneomsorgFor =
-                        harAleneomsorgForNoenBarn &&
-                        harAleneomsorgFor.some((barnId) => harAvtaleOmDeltBostedFor?.includes(barnId));
+                    const harAvtaleOmDeltBosted = avtaleOmDeltBosted === YesOrNo.YES;
+                    const harSvartPåOmManHarAvtaleOmDeltBosted = avtaleOmDeltBosted !== YesOrNo.UNANSWERED;
 
                     const clearHarAvtaleOmDeltBostedFor = (harAvtale: string) => {
-                        if (harAleneomsorgForNøyaktigEttBarn) {
-                            setFieldValue(
-                                OmOmsorgenForBarnFormFields.harAvtaleOmDeltBostedFor,
-                                harAvtale === YesOrNo.YES ? harAleneomsorgFor : [],
-                            );
-                        } else if (harFlereBarn) {
-                            setFieldValue(OmOmsorgenForBarnFormFields.harAvtaleOmDeltBostedFor, []);
-                        }
+                        setFieldValue(
+                            OmOmsorgenForBarnFormFields.harAvtaleOmDeltBostedFor,
+                            harAvtale === YesOrNo.YES ? harAleneomsorgFor : [],
+                        );
                     };
 
-                    const visVelgMinstEttBarnMedDeltBostedAdvarsel =
-                        harIkkeAleneomsorgForNoenBarn && harAvtaleOmDeltBosted;
-                    const kanIkkeFortsette =
-                        harIkkeAleneomsorgForNoenBarn || harAvtaleOmDeltBostedForNoenBarnManHarAleneomsorgFor;
+                    const kanIkkeFortsette = harIkkeAleneomsorgForNoenBarn || harAvtaleOmDeltBosted;
+
+                    const advarsel =
+                        harIkkeAleneomsorgForNoenBarn && harSvartPåOmManHarAvtaleOmDeltBosted
+                            ? text('steg.omOmsorgenForBarna.deltBosted.velgMinstEttBarnMedDeltBostedAdvarsel')
+                            : harAvtaleOmDeltBosted
+                              ? text('steg.omOmsorgenForBarn.alleBarnMedDeltBosted')
+                              : false;
 
                     return (
                         <>
@@ -234,32 +226,10 @@ const OmOmsorgenForBarnStep = () => {
                                                     }
                                                 />
                                             </Block>
-
-                                            {harAvtaleOmDeltBosted && harAleneomsorgForFlereBarn && (
-                                                <Block margin="xl">
-                                                    <CheckboxGroup
-                                                        legend={text('steg.omOmsorgenForBarn.deltBosted')}
-                                                        name={OmOmsorgenForBarnFormFields.harAvtaleOmDeltBostedFor}
-                                                        checkboxes={getBarnOptions(barnManHarAleneomsorgFor)}
-                                                        validate={getListValidator({ required: true })}
-                                                    />
-                                                </Block>
-                                            )}
                                         </Block>
-                                        {harAvtaleOmDeltBostedForNoenBarnManHarAleneomsorgFor && (
+                                        {advarsel && (
                                             <Block margin="l">
-                                                <Alert variant="warning">
-                                                    {text('steg.omOmsorgenForBarn.alleBarnMedDeltBosted')}
-                                                </Alert>
-                                            </Block>
-                                        )}
-                                        {visVelgMinstEttBarnMedDeltBostedAdvarsel && (
-                                            <Block margin="l">
-                                                <Alert variant="warning">
-                                                    {text(
-                                                        'steg.omOmsorgenForBarna.deltBosted.velgMinstEttBarnMedDeltBostedAdvarsel',
-                                                    )}
-                                                </Alert>
+                                                <Alert variant="warning">{advarsel}</Alert>
                                             </Block>
                                         )}
                                     </>

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/omOmsorgenForBarnMessages.ts
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/omOmsorgenForBarnMessages.ts
@@ -28,7 +28,7 @@ const nb = {
     'steg.omOmsorgenForBarn.form.fødtNavn': 'Født {dato} {navn}',
 
     'steg.omOmsorgenForBarn.alleBarnMedDeltBosted':
-        'Hvis du og den andre forelderen har en avtale om delt fast bosted, bor barnet fast hos dere begge. I disse tilfellene kan ingen av dere få ekstra dager på grunn av aleneomsorg, men dere har begge rett til ordinære omsorgsdager.',
+        'Du kan kun søke for barn du er alene med omsorgen for, og ikke har avtale om fast delt bosted for. Hvis du og den andre forelderen har en avtale om delt fast bosted, bor barnet fast hos dere begge. I disse tilfellene kan ingen av dere få ekstra dager på grunn av aleneomsorg, men dere har begge rett til ordinære omsorgsdager.',
     'steg.omOmsorgenForBarn.ingenbarn': 'Du må ha minst ett barn for å kunne gå videre.',
     'steg.omOmsorgenForBarn.nextButtonLabel': 'Fortsett',
 

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/omOmsorgenForBarnMessages.ts
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/omOmsorgenForBarnMessages.ts
@@ -21,7 +21,6 @@ const nb = {
     'steg.omOmsorgenForBarn.deltBosted.description.tittel': 'Hva er avtale om delt fast bosted?',
     'steg.omOmsorgenForBarn.deltBosted.description':
         'Avtale om delt fast bosted er en juridisk avtale i henhold til barneloven §36 og betyr at barnet har fast bosted hos begge foreldrene. Hvis det er avtalt delt fast bosted er ingen av foreldrene alene om omsorgen for barnet, men begge har rett til ordinære omsorgsdager.',
-    'steg.omOmsorgenForBarn.deltBosted': 'Kryss av for hvilke barn du har delt fast bosted for:',
     'steg.omOmsorgenForBarna.deltBosted.velgMinstEttBarnMedDeltBostedAdvarsel':
         'Du må ha aleneomsorg for minst ett barn for å kunne svare på hvilke(t) barn man har avtale om delt fast bosted for.',
 

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/omOmsorgenForBarnMessages.ts
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/omOmsorgenForBarnMessages.ts
@@ -22,6 +22,8 @@ const nb = {
     'steg.omOmsorgenForBarn.deltBosted.description':
         'Avtale om delt fast bosted er en juridisk avtale i henhold til barneloven §36 og betyr at barnet har fast bosted hos begge foreldrene. Hvis det er avtalt delt fast bosted er ingen av foreldrene alene om omsorgen for barnet, men begge har rett til ordinære omsorgsdager.',
     'steg.omOmsorgenForBarn.deltBosted': 'Kryss av for hvilke barn du har delt fast bosted for:',
+    'steg.omOmsorgenForBarna.deltBosted.velgMinstEttBarnMedDeltBostedAdvarsel':
+        'Du må ha aleneomsorg for minst ett barn for å kunne svare på hvilke(t) barn man har avtale om delt fast bosted for.',
 
     'steg.omOmsorgenForBarn.form.født': 'Født {dato}',
     'steg.omOmsorgenForBarn.form.fødtNavn': 'Født {dato} {navn}',

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/omOmsorgenForBarnStepUtils.tsx
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/om-omsorgen-for-barn/omOmsorgenForBarnStepUtils.tsx
@@ -89,31 +89,21 @@ export const barnItemLabelRenderer = (registrertBarn: RegistrertBarn): React.Rea
     );
 };
 
-export const getBarnOptions = (registrertBarn: RegistrertBarn[] = [], andreBarn: AnnetBarn[] = []) => {
-    return [
-        ...registrertBarn.map((barnet) => ({
-            label: (
-                <AppText
-                    id="steg.omOmsorgenForBarn.form.fødtNavn"
-                    values={{
-                        dato: dateFormatter.compact(barnet.fødselsdato),
-                        navn: formatName(barnet.fornavn, barnet.etternavn),
-                    }}
-                />
-            ),
-            value: barnet.aktørId,
-        })),
-        ...andreBarn.map((barnet) => ({
-            label: (
-                <AppText
-                    id="steg.omOmsorgenForBarn.form.fødtNavn"
-                    values={{
-                        dato: dateFormatter.compact(barnet.fødselsdato),
-                        navn: barnet.navn,
-                    }}
-                />
-            ),
-            value: barnet.fnr,
-        })),
-    ];
+export const getBarnOptions = (barn: (RegistrertBarn | AnnetBarn)[] = []) => {
+    return barn.map((barnet) => ({
+        label: (
+            <AppText
+                id="steg.omOmsorgenForBarn.form.fødtNavn"
+                values={{
+                    dato: dateFormatter.compact(barnet.fødselsdato),
+                    navn: erRegistrertBarn(barnet) ? formatName(barnet.fornavn, barnet.etternavn) : barnet.navn,
+                }}
+            />
+        ),
+        value: erRegistrertBarn(barnet) ? barnet.aktørId : barnet.fnr,
+    }));
+};
+
+const erRegistrertBarn = (barn: RegistrertBarn | AnnetBarn): barn is RegistrertBarn => {
+    return 'aktørId' in barn;
 };


### PR DESCRIPTION
Denne PRen gjør at vi ikke spør om informasjon vi ikke trenger for å behandle en søknad.

Vi spør ikke lenger om hvilke barn man har delt bosted for – vi sier bare ifra at dersom man søker for noen man har delt bosted for, så får du ikke lov til det.

Om man ikke har valgt barn enda, viser vi nå en ny advarsel om at du må velge et barn å søke om før.