### PR TITLE
Bugfix SoknadHeader

### DIFF
--- a/.changeset/big-masks-attend.md
+++ b/.changeset/big-masks-attend.md
@@ -1,0 +1,5 @@
+---
+'@navikt/sif-common-soknad-ds': patch
+---
+
+Sette wrap=false for SoknadHeader

--- a/packages/sif-common-soknad-ds/src/components/soknad-header/SoknadHeader.tsx
+++ b/packages/sif-common-soknad-ds/src/components/soknad-header/SoknadHeader.tsx
@@ -11,7 +11,7 @@ interface Props {
 const SoknadHeader: React.FunctionComponent<Props> = ({ title, level = '1' }) => (
     <div style={{ boxShadow: '0 -4px 0 var(--a-deepblue-400) inset' }}>
         <PageBoundary>
-            <HStack gap="4" paddingBlock="2 2" align={'center'}>
+            <HStack gap="4" paddingBlock="2 2" align={'center'} wrap={false}>
                 <Show above="sm">
                     <ApplicationPictogram style={{ width: '2.5rem', height: '2.5rem' }} />
                 </Show>


### PR DESCRIPTION
Sette wrap=false slik at ikon og tittel er på samme linje selv om tittel på dialog er lang