### PR TITLE
Fix url for vedlegg - arbeidsforhold

### DIFF
--- a/.changeset/twelve-foxes-remember.md
+++ b/.changeset/twelve-foxes-remember.md
@@ -1,6 +1,0 @@
----
-'@navikt/omsorgspengerutbetaling-arbeidstaker-soknad': patch
-'@navikt/pleiepenger-i-livets-sluttfase-soknad': patch
----
-
-Bugfix - legge på fixAttachmentURL

--- a/.changeset/twelve-foxes-remember.md
+++ b/.changeset/twelve-foxes-remember.md
@@ -1,0 +1,6 @@
+---
+'@navikt/omsorgspengerutbetaling-arbeidstaker-soknad': patch
+'@navikt/pleiepenger-i-livets-sluttfase-soknad': patch
+---
+
+Bugfix - legge på fixAttachmentURL

--- a/apps/omsorgspengerutbetaling-arbeidstaker-soknad/CHANGELOG.md
+++ b/apps/omsorgspengerutbetaling-arbeidstaker-soknad/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @navikt/omsorgspengerutbetaling-arbeidstaker-soknad
 
+## 1.5.5
+
+### Patch Changes
+
+-   d5466f2: Bugfix - legge på fixAttachmentURL
+
 ## 1.5.4
 
 ### Patch Changes

--- a/apps/omsorgspengerutbetaling-arbeidstaker-soknad/package.json
+++ b/apps/omsorgspengerutbetaling-arbeidstaker-soknad/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "name": "@navikt/omsorgspengerutbetaling-arbeidstaker-soknad",
     "repository": "https://github.com/navikt/sif-brukerdialog",
-    "version": "1.5.4",
+    "version": "1.5.5",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/apps/omsorgspengerutbetaling-arbeidstaker-soknad/src/app/søknad/steps/situasjon/form-parts/ArbeidsforholdAttachmentList.tsx
+++ b/apps/omsorgspengerutbetaling-arbeidstaker-soknad/src/app/søknad/steps/situasjon/form-parts/ArbeidsforholdAttachmentList.tsx
@@ -18,7 +18,7 @@ interface Props {
     wrapNoAttachmentsInBlock?: boolean;
 }
 
-const LegeerklæringAvtaleAttachmentList: React.FunctionComponent<Props> = ({
+const ArbeidsforholdAttachmentList: React.FunctionComponent<Props> = ({
     wrapNoAttachmentsInBlock,
     dokumenter,
     fieldName,
@@ -59,4 +59,4 @@ const LegeerklæringAvtaleAttachmentList: React.FunctionComponent<Props> = ({
     }
 };
 
-export default LegeerklæringAvtaleAttachmentList;
+export default ArbeidsforholdAttachmentList;

--- a/apps/omsorgspengerutbetaling-arbeidstaker-soknad/src/app/søknad/steps/situasjon/form-parts/ArbeidsforholdUtbetalingsårsak.tsx
+++ b/apps/omsorgspengerutbetaling-arbeidstaker-soknad/src/app/søknad/steps/situasjon/form-parts/ArbeidsforholdUtbetalingsårsak.tsx
@@ -13,16 +13,15 @@ import {
 import { validateAll } from '@navikt/sif-common-formik-ds/src/validation/validationUtils';
 import { useFormikContext } from 'formik';
 import { ApiEndpoint } from '../../../../api/api';
-// import { valuesToAlleDokumenterISøknaden } from '../../../../utils/attachmentUtils';
 import FormikFileUploader from '../../../../components/formik-file-uploader/FormikFileUploader';
 import { useAppIntl } from '../../../../i18n';
 import { Arbeidsforhold, Utbetalingsårsak, ÅrsakNyoppstartet } from '../../../../types/ArbeidsforholdTypes';
+import { fixAttachmentURL } from '../../../../utils/attachmentUtils';
 import { relocateToLoginPage } from '../../../../utils/navigationUtils';
 import { validateAttachments, ValidateAttachmentsErrors } from '../../../../utils/validateAttachments';
 import { AppFieldValidationErrors } from '../../../../utils/validations';
 import { ArbeidsforholdFormFields, SituasjonFormValues } from '../SituasjonStep';
 import ArbeidsforholdAttachmentList from './ArbeidsforholdAttachmentList';
-import { fixAttachmentURL } from '../../../../utils/attachmentUtils';
 
 const { RadioGroup, Textarea } = getTypedFormComponents<ArbeidsforholdFormFields, Arbeidsforhold, ValidationError>();
 
@@ -45,7 +44,6 @@ const ArbeidsforholdUtbetalingsårsak = ({ arbeidsforhold, parentFieldName }: Pr
         return arbeidsforhold ? arbeidsforhold.dokumenter.map(fixAttachmentURL) : [];
     }, [arbeidsforhold]);
 
-    // const alleDokumenterISøknaden: Attachment[] = valuesToAlleDokumenterISøknaden(values);
     const ref = useRef({ attachments });
 
     useEffect(() => {

--- a/apps/omsorgspengerutbetaling-arbeidstaker-soknad/src/app/søknad/steps/situasjon/form-parts/ArbeidsforholdUtbetalingsårsak.tsx
+++ b/apps/omsorgspengerutbetaling-arbeidstaker-soknad/src/app/søknad/steps/situasjon/form-parts/ArbeidsforholdUtbetalingsårsak.tsx
@@ -22,6 +22,7 @@ import { validateAttachments, ValidateAttachmentsErrors } from '../../../../util
 import { AppFieldValidationErrors } from '../../../../utils/validations';
 import { ArbeidsforholdFormFields, SituasjonFormValues } from '../SituasjonStep';
 import ArbeidsforholdAttachmentList from './ArbeidsforholdAttachmentList';
+import { fixAttachmentURL } from '../../../../utils/attachmentUtils';
 
 const { RadioGroup, Textarea } = getTypedFormComponents<ArbeidsforholdFormFields, Arbeidsforhold, ValidationError>();
 
@@ -41,7 +42,7 @@ const ArbeidsforholdUtbetalingsårsak = ({ arbeidsforhold, parentFieldName }: Pr
     const arbeidsgivernavn = arbeidsforhold.navn;
 
     const attachments: Attachment[] = useMemo(() => {
-        return arbeidsforhold ? arbeidsforhold.dokumenter : [];
+        return arbeidsforhold ? arbeidsforhold.dokumenter.map(fixAttachmentURL) : [];
     }, [arbeidsforhold]);
 
     // const alleDokumenterISøknaden: Attachment[] = valuesToAlleDokumenterISøknaden(values);

--- a/apps/pleiepenger-i-livets-sluttfase-soknad/CHANGELOG.md
+++ b/apps/pleiepenger-i-livets-sluttfase-soknad/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @navikt/pleiepenger-i-livets-sluttfase-soknad
 
+## 2.10.5
+
+### Patch Changes
+
+-   d5466f2: Bugfix - legge på fixAttachmentURL
+
 ## 2.10.4
 
 ### Patch Changes

--- a/apps/pleiepenger-i-livets-sluttfase-soknad/package.json
+++ b/apps/pleiepenger-i-livets-sluttfase-soknad/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "name": "@navikt/pleiepenger-i-livets-sluttfase-soknad",
     "repository": "https://github.com/navikt/sif-brukerdialog",
-    "version": "2.10.4",
+    "version": "2.10.5",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/apps/pleiepenger-i-livets-sluttfase-soknad/src/app/søknad/steps/legeerklæring/LegeerklæringAttachmentList.tsx
+++ b/apps/pleiepenger-i-livets-sluttfase-soknad/src/app/søknad/steps/legeerklæring/LegeerklæringAttachmentList.tsx
@@ -13,6 +13,7 @@ import { useFormikContext } from 'formik';
 import api from '../../../api/api';
 import { LegeerklæringFormFields, LegeerklæringFormValues } from './LegeerklæringForm';
 import { AppText } from '../../../i18n';
+import { fixAttachmentURL } from '../../../utils/attachmentUtils';
 
 interface Props {
     includeDeletionFunctionality: boolean;
@@ -24,7 +25,9 @@ const LegeerklæringAvtaleAttachmentList: React.FunctionComponent<Props> = ({
     includeDeletionFunctionality,
 }) => {
     const { values, setFieldValue } = useFormikContext<LegeerklæringFormValues>();
-    const avtale: Attachment[] = values.vedlegg.filter(({ file }: Attachment) => fileExtensionIsValid(file.name));
+    const avtale: Attachment[] = values.vedlegg
+        .filter(({ file }: Attachment) => fileExtensionIsValid(file.name))
+        .map(fixAttachmentURL);
 
     if (!containsAnyUploadedAttachments(avtale)) {
         const noAttachmentsText = (


### PR DESCRIPTION
Korrigere komponentnavn i fil og legge på en glemt fixAttachmentURL for dem som har startet søknad med mellomlagring og har gammel url til vedlegg i frontend.