### PR TITLE
Fix oms kronisk oppsummering delt bosted

### DIFF
--- a/apps/omsorgspengesoknad/CHANGELOG.md
+++ b/apps/omsorgspengesoknad/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @navikt/omsorgspengesoknad
 
+## 1.33.12
+
+### Patch Changes
+
+-   Bugfix. Ikke vise melding om manglende avtale for delt bosted når bruker ikke har delt bosted.
+
 ## 1.33.11
 
 ### Patch Changes

--- a/apps/omsorgspengesoknad/package.json
+++ b/apps/omsorgspengesoknad/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "name": "@navikt/omsorgspengesoknad",
     "repository": "https://github.com/navikt/sif-brukerdialog",
-    "version": "1.33.11",
+    "version": "1.33.12",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/apps/omsorgspengesoknad/src/app/søknad/steps/oppsummering/parts/VedleggOppsummering.tsx
+++ b/apps/omsorgspengesoknad/src/app/søknad/steps/oppsummering/parts/VedleggOppsummering.tsx
@@ -21,10 +21,12 @@ const VedleggOppsummering: React.FunctionComponent<Props> = ({
         locations: apiData.legeerklæring,
         attachments: legeerklæringSøknadsdata?.vedlegg,
     });
-    const samværsavtaler = getAttachmentsInLocationArray({
-        locations: apiData.samværsavtale,
-        attachments: samværsavtaleSøknadsdata?.vedlegg,
-    });
+    const samværsavtaler = samværsavtaleSøknadsdata
+        ? getAttachmentsInLocationArray({
+              locations: apiData.samværsavtale,
+              attachments: samværsavtaleSøknadsdata?.vedlegg,
+          })
+        : undefined;
     return (
         <FormSummary>
             <FormSummary.Header>


### PR DESCRIPTION
-   Bugfix. Ikke vise melding om manglende avtale for delt bosted når bruker ikke har delt bosted.
