### PR TITLE
Bugfix aleneomsorg

### DIFF
--- a/apps/omsorgsdager-aleneomsorg-dialog/mock/mock-data/barn.json
+++ b/apps/omsorgsdager-aleneomsorg-dialog/mock/mock-data/barn.json
@@ -1,12 +1,11 @@
 {
     "barn": [
         {
-            "fødselsdato": "1990-01-02",
-            "fornavn": "Barn",
-            "mellomnavn": "Barne",
-            "etternavn": "Barnesen",
-            "aktørId": "1"
-        },
-        { "fødselsdato": "1990-01-02", "fornavn": "Mock", "etternavn": "Mocknes", "aktørId": "2" }
+            "aktørId": "2625355633955",
+            "etternavn": "FUNKSJONÆR",
+            "fornavn": "FORNUFTIG",
+            "fødselsdato": "2022-11-02",
+            "mellomnavn": null
+        }
     ]
 }

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/constants/SØKNAD_VERSJON.ts
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/constants/SØKNAD_VERSJON.ts
@@ -1,1 +1,1 @@
-export const SØKNAD_VERSJON = '1.0.0';
+export const SØKNAD_VERSJON = '1.0.1';

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/tidspunkt-for-aleneomsorg/TidspunktForAleneomsorgStep.tsx
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/tidspunkt-for-aleneomsorg/TidspunktForAleneomsorgStep.tsx
@@ -30,12 +30,13 @@ export enum TidspunktForAleneomsorg {
     TIDLIGERE = 'TIDLIGERE',
 }
 
-export type AleneomsorgTidspunkt = {
-    [fnr: string]: {
+export type AleneomsorgTidspunkt = Record<
+    string,
+    {
         tidspunktForAleneomsorg?: TidspunktForAleneomsorg;
         dato?: string;
-    };
-};
+    }
+>;
 
 export enum AleneomsorgTidspunktField {
     tidspunktForAleneomsorg = 'tidspunktForAleneomsorg',

--- a/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/tidspunkt-for-aleneomsorg/tidspunktForAleneomsorgStepUtils.ts
+++ b/apps/omsorgsdager-aleneomsorg-dialog/src/app/søknad/steps/tidspunkt-for-aleneomsorg/tidspunktForAleneomsorgStepUtils.ts
@@ -55,18 +55,31 @@ export const getTidspunktForAleneomsorgSøknadsdataFromFormValues = (
 
 export const mapRegistrertBarnToBarnMedAleneomsorg = (registrertBarn: RegistrertBarn): BarnMedAleneomsorg => {
     return {
-        idFnr: registrertBarn.aktørId,
+        idFnr: prefixBarnIdFnr(registrertBarn.aktørId),
         navn: formatName(registrertBarn.fornavn, registrertBarn.etternavn, registrertBarn.mellomnavn),
     };
 };
 
 export const mapAnnetBarnToBarnMedAleneomsorg = (annetBarn: AnnetBarn): BarnMedAleneomsorg => {
     return {
-        idFnr: annetBarn.fnr,
+        idFnr: prefixBarnIdFnr(annetBarn.fnr),
         navn: annetBarn.navn,
     };
 };
 export const getYear = (yearsToSubtract: number): string => (dayjs().year() - yearsToSubtract).toString();
+
+/**
+ *
+ * @param idFnr Legger på 'idFnr_' før nummer, slik at en unngår at formik bruker fnr eller id som index i errorArray
+ * @returns
+ */
+export const prefixBarnIdFnr = (idFnr: string): string => `idFnr_${idFnr}`;
+/**
+ *
+ * @param idFnr Fjerner på 'idFnr_' for å bruke originalt fnr eller id
+ * @returns
+ */
+export const unprefixBarnIdFnr = (prefixedIdFnr: string): string => prefixedIdFnr.replace('idFnr_', '');
 
 export const getMinDateYearAgo = (): Date => {
     dayjs.extend(dayOfYear);


### PR DESCRIPTION
Valideringsmelding for tidspunkt for aleneomsorg var ikke synlig pga. at formik tolket fnr som index. Endret fieldName til å være prefikset, slik at det blir en string. Unprefixer igjen når en setter sammen apiData.