### PR TITLE
Legg til sif-code-scan i CI

### DIFF
--- a/.github/workflows/test-changed-apps.yml
+++ b/.github/workflows/test-changed-apps.yml
@@ -286,5 +286,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@v1
 

--- a/.github/workflows/test-changed-apps.yml
+++ b/.github/workflows/test-changed-apps.yml
@@ -285,5 +285,6 @@ jobs:
   sif-code-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+

--- a/.github/workflows/test-changed-apps.yml
+++ b/.github/workflows/test-changed-apps.yml
@@ -281,3 +281,9 @@ jobs:
       use-turbo-test: true
       e2e-build-command: "e2e:build"
       run-sonar: true
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/apps/dine-pleiepenger/src/auth/fakeLocalAuthTokenSet.json
+++ b/apps/dine-pleiepenger/src/auth/fakeLocalAuthTokenSet.json
@@ -4,7 +4,7 @@
         "sub": "3d8a4dc8-ac09-4de2-bba8-2b87e0f2ef66",
         "iss": "https://example.com/oidc-provider/",
         "client_amr": "private_key_jwt",
-        "pid": "08089408084",
+        "pid": "18410162721",
         "token_type": "Bearer",
         "client_id": "21f19b49-904c-491a-b07e-7a702cdf54aa",
         "aud": "https://example.com",

--- a/packages/sif-common-formik-ds/storybook/stories/validation/ValidationExample.tsx
+++ b/packages/sif-common-formik-ds/storybook/stories/validation/ValidationExample.tsx
@@ -397,11 +397,11 @@ const error = getFødselsnummerValidator(options)(value);
                                     <Form.TextField
                                         name={FormFields.fødselsnummer}
                                         width="m"
-                                        description='Eksempelfødselsnummeret "19081988075" er ditt eget, og er ikke tillatt'
+                                        description='Eksempelfødselsnummeret "17420373147" er ditt eget, og er ikke tillatt'
                                         label="Hva er barnets fødselsnummer / D-nummer?"
                                         validate={getFødselsnummerValidator({
                                             required: true,
-                                            disallowedValues: ['19081988075'],
+                                            disallowedValues: ['17420373147'],
                                         })}
                                     />
                                 </Panel>

--- a/packages/sif-validation/src/__tests__/validateFødselsnummer.test.ts
+++ b/packages/sif-validation/src/__tests__/validateFødselsnummer.test.ts
@@ -1,8 +1,8 @@
 import getFødselsnummerValidator, { ValidateFødselsnummerError } from '../getFødselsnummerValidator';
 
 describe(`validateFødselsnummer`, () => {
-    const generatedFnr = '24090014427';
-    const generatedFnr2 = '19035114443';
+    const generatedFnr = '24420167209';
+    const generatedFnr2 = '18410162721';
     const hnr = '13527248013';
 
     it('returns undefined when the fødselsnummer is valid', () => {


### PR DESCRIPTION
Legger til sif-code-scan som en parallell jobb i CI-workflowen. Denne sjekker koden for sensitive data som fødselsnummer.