### PR TITLE
Oppdatere nav-dekoratoren-moduler fra 3 til 4 og tilpasse CI til Node 24

### DIFF
--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: ".github/workflows/*.{yml,yaml}"
+applyTo: '.github/workflows/*.{yml,yaml}'
 ---
 
 # GitHub Actions CI/CD Standards
@@ -41,49 +41,49 @@ Standard deploy workflow for Nav apps:
 name: Build and deploy
 
 on:
-  push:
-    branches: [main]
+    push:
+        branches: [main]
 
 permissions:
-  contents: read
-  id-token: write
+    contents: read
+    id-token: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.docker-build-push.outputs.image }}
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    build:
+        runs-on: ubuntu-latest
+        outputs:
+            image: ${{ steps.docker-build-push.outputs.image }}
+        steps:
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: nais/docker-build-push@v0
-        id: docker-build-push
-        with:
-          team: mitt-team
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+            - uses: nais/docker-build-push@v0
+              id: docker-build-push
+              with:
+                  team: mitt-team
+                  identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+                  project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
 
-  deploy-dev:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: dev-gcp
-          RESOURCE: .nais/nais.yaml
-          VAR: image=${{ needs.build.outputs.image }}
+    deploy-dev:
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+            - uses: nais/deploy/actions/deploy@v2
+              env:
+                  CLUSTER: dev-gcp
+                  RESOURCE: .nais/nais.yaml
+                  VAR: image=${{ needs.build.outputs.image }}
 
-  deploy-prod:
-    needs: [build, deploy-dev]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: prod-gcp
-          RESOURCE: .nais/nais.yaml
-          VAR: image=${{ needs.build.outputs.image }}
+    deploy-prod:
+        needs: [build, deploy-dev]
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+            - uses: nais/deploy/actions/deploy@v2
+              env:
+                  CLUSTER: prod-gcp
+                  RESOURCE: .nais/nais.yaml
+                  VAR: image=${{ needs.build.outputs.image }}
 ```
 
 ## Caching
@@ -92,32 +92,32 @@ jobs:
 # Gradle
 - uses: actions/setup-java@v4
   with:
-    distribution: temurin
-    java-version: 21
-    cache: gradle
+      distribution: temurin
+      java-version: 21
+      cache: gradle
 
 # Node/pnpm
 - uses: actions/setup-node@v4
   with:
-    node-version: 22
-    cache: pnpm
+      node-version: 24
+      cache: pnpm
 
 # Go
 - uses: actions/setup-go@v5
   with:
-    go-version-file: go.mod
-    cache: true
+      go-version-file: go.mod
+      cache: true
 ```
 
 ## Matrix Builds
 
 ```yaml
 strategy:
-  fail-fast: false
-  matrix:
-    app: [my-app, my-other-app]
+    fail-fast: false
+    matrix:
+        app: [my-app, my-other-app]
 steps:
-  - run: cd apps/${{ matrix.app }} && ./gradlew build
+    - run: cd apps/${{ matrix.app }} && ./gradlew build
 ```
 
 ## Reusable Workflows
@@ -125,31 +125,31 @@ steps:
 ```yaml
 # .github/workflows/deploy-nais.yml (reusable)
 on:
-  workflow_call:
-    inputs:
-      cluster:
-        required: true
-        type: string
-      resource:
-        required: true
-        type: string
-      image:
-        required: true
-        type: string
+    workflow_call:
+        inputs:
+            cluster:
+                required: true
+                type: string
+            resource:
+                required: true
+                type: string
+            image:
+                required: true
+                type: string
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: ${{ inputs.cluster }}
-          RESOURCE: ${{ inputs.resource }}
-          VAR: image=${{ inputs.image }}
+    deploy:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+            - uses: nais/deploy/actions/deploy@v2
+              env:
+                  CLUSTER: ${{ inputs.cluster }}
+                  RESOURCE: ${{ inputs.resource }}
+                  VAR: image=${{ inputs.image }}
 ```
 
 ## Secrets
@@ -172,14 +172,14 @@ env:
 ```yaml
 # Begrens concurrency — unngå parallelle deploys
 concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+    group: deploy-${{ github.ref }}
+    cancel-in-progress: true
 
 # Timeout — unngå hengende jobs
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    build:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
 ```
 
 ## Scanning
@@ -188,9 +188,9 @@ jobs:
 # Vulnerability scanning med trivy
 - uses: aquasecurity/trivy-action@0.28.0
   with:
-    scan-type: fs
-    severity: HIGH,CRITICAL
-    exit-code: 1
+      scan-type: fs
+      severity: HIGH,CRITICAL
+      exit-code: 1
 
 # GitHub Actions security scanning
 - run: pipx run zizmor .github/workflows/

--- a/.github/skills/playwright-testing/SKILL.md
+++ b/.github/skills/playwright-testing/SKILL.md
@@ -29,29 +29,29 @@ npx playwright init
 ### playwright.config.ts
 
 ```typescript
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  testDir: "./e2e",
-  fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: [["html", { open: "never" }]],
-  use: {
-    baseURL: process.env.BASE_URL ?? "http://localhost:3000",
-    trace: "on-first-retry",
-    screenshot: "only-on-failure",
-  },
-  projects: [
-    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
-    { name: "mobile", use: { ...devices["Pixel 7"] } },
-  ],
-  webServer: {
-    command: "pnpm dev",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
-  },
+    testDir: './e2e',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: [['html', { open: 'never' }]],
+    use: {
+        baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+    },
+    projects: [
+        { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+        { name: 'mobile', use: { ...devices['Pixel 7'] } },
+    ],
+    webServer: {
+        command: 'pnpm dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+    },
 });
 ```
 
@@ -59,34 +59,34 @@ export default defineConfig({
 
 ```typescript
 // e2e/pages/oversikt.page.ts
-import { type Locator, type Page, expect } from "@playwright/test";
+import { type Locator, type Page, expect } from '@playwright/test';
 
 export class OversiktPage {
-  readonly heading: Locator;
-  readonly searchField: Locator;
-  readonly table: Locator;
+    readonly heading: Locator;
+    readonly searchField: Locator;
+    readonly table: Locator;
 
-  constructor(private readonly page: Page) {
-    this.heading = page.getByRole("heading", { name: /oversikt/i });
-    this.searchField = page.getByRole("searchbox", { name: /søk/i });
-    this.table = page.getByRole("table");
-  }
+    constructor(private readonly page: Page) {
+        this.heading = page.getByRole('heading', { name: /oversikt/i });
+        this.searchField = page.getByRole('searchbox', { name: /søk/i });
+        this.table = page.getByRole('table');
+    }
 
-  async goto() {
-    await this.page.goto("/oversikt");
-    await expect(this.heading).toBeVisible();
-  }
+    async goto() {
+        await this.page.goto('/oversikt');
+        await expect(this.heading).toBeVisible();
+    }
 
-  async search(query: string) {
-    await this.searchField.fill(query);
-    await this.searchField.press("Enter");
-  }
+    async search(query: string) {
+        await this.searchField.fill(query);
+        await this.searchField.press('Enter');
+    }
 
-  async expectRowCount(count: number) {
-    const rows = this.table.getByRole("row");
-    // Minus header row
-    await expect(rows).toHaveCount(count + 1);
-  }
+    async expectRowCount(count: number) {
+        const rows = this.table.getByRole('row');
+        // Minus header row
+        await expect(rows).toHaveCount(count + 1);
+    }
 }
 ```
 
@@ -94,28 +94,28 @@ export class OversiktPage {
 
 ```typescript
 // e2e/fixtures/auth.ts
-import { test as base } from "@playwright/test";
+import { test as base } from '@playwright/test';
 
 type AuthFixtures = {
-  authenticatedPage: ReturnType<typeof base["page"]>;
+    authenticatedPage: ReturnType<(typeof base)['page']>;
 };
 
 export const test = base.extend<AuthFixtures>({
-  authenticatedPage: async ({ page, context }, use) => {
-    // Set auth cookie for test environment
-    await context.addCookies([
-      {
-        name: "selvbetjening-idtoken",
-        value: process.env.TEST_TOKEN ?? "test-token",
-        domain: "localhost",
-        path: "/",
-      },
-    ]);
-    await use(page);
-  },
+    authenticatedPage: async ({ page, context }, use) => {
+        // Set auth cookie for test environment
+        await context.addCookies([
+            {
+                name: 'selvbetjening-idtoken',
+                value: process.env.TEST_TOKEN ?? 'test-token',
+                domain: 'localhost',
+                path: '/',
+            },
+        ]);
+        await use(page);
+    },
 });
 
-export { expect } from "@playwright/test";
+export { expect } from '@playwright/test';
 ```
 
 ## 4. Test Examples
@@ -124,20 +124,20 @@ export { expect } from "@playwright/test";
 
 ```typescript
 // e2e/tests/navigation.spec.ts
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-test.describe("Navigation", () => {
-  test("should navigate to oversikt page", async ({ page }) => {
-    await page.goto("/");
-    await page.getByRole("link", { name: /oversikt/i }).click();
-    await expect(page).toHaveURL(/\/oversikt/);
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
-  });
+test.describe('Navigation', () => {
+    test('should navigate to oversikt page', async ({ page }) => {
+        await page.goto('/');
+        await page.getByRole('link', { name: /oversikt/i }).click();
+        await expect(page).toHaveURL(/\/oversikt/);
+        await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    });
 
-  test("should show 404 for unknown routes", async ({ page }) => {
-    const response = await page.goto("/ukjent-side");
-    expect(response?.status()).toBe(404);
-  });
+    test('should show 404 for unknown routes', async ({ page }) => {
+        const response = await page.goto('/ukjent-side');
+        expect(response?.status()).toBe(404);
+    });
 });
 ```
 
@@ -145,27 +145,27 @@ test.describe("Navigation", () => {
 
 ```typescript
 // e2e/tests/form.spec.ts
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-test.describe("Søknadsskjema", () => {
-  test("should submit form successfully", async ({ page }) => {
-    await page.goto("/soknad");
+test.describe('Søknadsskjema', () => {
+    test('should submit form successfully', async ({ page }) => {
+        await page.goto('/soknad');
 
-    await page.getByLabel("Navn").fill("Ola Nordmann");
-    await page.getByLabel("E-post").fill("ola@nav.no");
-    await page.getByRole("combobox", { name: /tema/i }).selectOption("dagpenger");
-    await page.getByRole("button", { name: /send inn/i }).click();
+        await page.getByLabel('Navn').fill('Ola Nordmann');
+        await page.getByLabel('E-post').fill('ola@nav.no');
+        await page.getByRole('combobox', { name: /tema/i }).selectOption('dagpenger');
+        await page.getByRole('button', { name: /send inn/i }).click();
 
-    await expect(page.getByRole("alert")).toContainText("Sendt");
-  });
+        await expect(page.getByRole('alert')).toContainText('Sendt');
+    });
 
-  test("should show validation errors", async ({ page }) => {
-    await page.goto("/soknad");
-    await page.getByRole("button", { name: /send inn/i }).click();
+    test('should show validation errors', async ({ page }) => {
+        await page.goto('/soknad');
+        await page.getByRole('button', { name: /send inn/i }).click();
 
-    await expect(page.getByText("Navn er påkrevd")).toBeVisible();
-    await expect(page.getByText("E-post er påkrevd")).toBeVisible();
-  });
+        await expect(page.getByText('Navn er påkrevd')).toBeVisible();
+        await expect(page.getByText('E-post er påkrevd')).toBeVisible();
+    });
 });
 ```
 
@@ -173,26 +173,26 @@ test.describe("Søknadsskjema", () => {
 
 ```typescript
 // e2e/tests/responsive.spec.ts
-import { test, expect, devices } from "@playwright/test";
+import { test, expect, devices } from '@playwright/test';
 
-test.describe("Responsive", () => {
-  test("should show mobile menu on small screens", async ({ page }) => {
-    await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto("/");
+test.describe('Responsive', () => {
+    test('should show mobile menu on small screens', async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 812 });
+        await page.goto('/');
 
-    await expect(page.getByRole("button", { name: /meny/i })).toBeVisible();
-    await expect(page.getByRole("navigation")).not.toBeVisible();
+        await expect(page.getByRole('button', { name: /meny/i })).toBeVisible();
+        await expect(page.getByRole('navigation')).not.toBeVisible();
 
-    await page.getByRole("button", { name: /meny/i }).click();
-    await expect(page.getByRole("navigation")).toBeVisible();
-  });
+        await page.getByRole('button', { name: /meny/i }).click();
+        await expect(page.getByRole('navigation')).toBeVisible();
+    });
 
-  test("should show full navigation on desktop", async ({ page }) => {
-    await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto("/");
+    test('should show full navigation on desktop', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 800 });
+        await page.goto('/');
 
-    await expect(page.getByRole("navigation")).toBeVisible();
-  });
+        await expect(page.getByRole('navigation')).toBeVisible();
+    });
 });
 ```
 
@@ -200,22 +200,20 @@ test.describe("Responsive", () => {
 
 ```typescript
 // e2e/tests/accessibility.spec.ts
-import { test, expect } from "@playwright/test";
-import AxeBuilder from "@axe-core/playwright";
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
 
-test.describe("Accessibility", () => {
-  const pages = ["/", "/oversikt", "/usage"];
+test.describe('Accessibility', () => {
+    const pages = ['/', '/oversikt', '/usage'];
 
-  for (const path of pages) {
-    test(`${path} should have no a11y violations`, async ({ page }) => {
-      await page.goto(path);
-      const results = await new AxeBuilder({ page })
-        .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
-        .analyze();
+    for (const path of pages) {
+        test(`${path} should have no a11y violations`, async ({ page }) => {
+            await page.goto(path);
+            const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21aa']).analyze();
 
-      expect(results.violations).toEqual([]);
-    });
-  }
+            expect(results.violations).toEqual([]);
+        });
+    }
 });
 ```
 
@@ -224,22 +222,22 @@ test.describe("Accessibility", () => {
 ```yaml
 # .github/workflows/e2e.yml
 e2e:
-  runs-on: ubuntu-latest
-  timeout-minutes: 10
-  steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 22
-        cache: pnpm
-    - run: pnpm install --frozen-lockfile
-    - run: npx playwright install --with-deps chromium
-    - run: pnpm exec playwright test
-    - uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: playwright-report
-        path: playwright-report/
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-node@v4
+          with:
+              node-version: 24
+              cache: pnpm
+        - run: pnpm install --frozen-lockfile
+        - run: npx playwright install --with-deps chromium
+        - run: pnpm exec playwright test
+        - uses: actions/upload-artifact@v4
+          if: failure()
+          with:
+              name: playwright-report
+              path: playwright-report/
 ```
 
 ## Locator Strategies
@@ -248,23 +246,23 @@ Prioritized order for finding elements:
 
 ```typescript
 // 1. ✅ Role-based (best)
-page.getByRole("button", { name: /send inn/i });
-page.getByRole("heading", { level: 1 });
-page.getByRole("link", { name: /oversikt/i });
+page.getByRole('button', { name: /send inn/i });
+page.getByRole('heading', { level: 1 });
+page.getByRole('link', { name: /oversikt/i });
 
 // 2. ✅ Label-based (for form elements)
-page.getByLabel("Fødselsnummer");
-page.getByPlaceholder("Søk...");
+page.getByLabel('Fødselsnummer');
+page.getByPlaceholder('Søk...');
 
 // 3. ✅ Text-based (for static content)
-page.getByText("Ingen resultater");
+page.getByText('Ingen resultater');
 
 // 4. ⚠️ Test ID (only when role/label doesn't work)
-page.getByTestId("metrics-chart");
+page.getByTestId('metrics-chart');
 
 // 5. ❌ CSS selectors (avoid)
-page.locator(".my-class");
-page.locator("#my-id");
+page.locator('.my-class');
+page.locator('#my-id');
 ```
 
 ## Tips

--- a/.github/workflows/.deploy-app-to-dev.yml
+++ b/.github/workflows/.deploy-app-to-dev.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Setup Node.js environment
               uses: actions/setup-node@v6.4.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: "pnpm"
 
             - name: Install dependencies

--- a/.github/workflows/.deploy-app-to-intern-prod.yml
+++ b/.github/workflows/.deploy-app-to-intern-prod.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Setup Node.js environment
               uses: actions/setup-node@v6.4.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: "pnpm"
 
             - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
                   IMAGE: ${{ steps.docker-push.outputs.image }}
 
     trivy:
-        needs: [ deploy-to-prod ]
+        needs: [deploy-to-prod]
         uses: navikt/sif-gha-workflows/.github/workflows/trivy.yml@main
         permissions:
             contents: write

--- a/.github/workflows/.deploy-app-to-prod.yml
+++ b/.github/workflows/.deploy-app-to-prod.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Setup Node.js environment
               uses: actions/setup-node@v6.4.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: "pnpm"
 
             - name: Install dependencies
@@ -78,7 +78,7 @@ jobs:
                   IMAGE: ${{ steps.docker-push.outputs.image }}
 
     trivy:
-        needs: [ deploy-to-prod ]
+        needs: [deploy-to-prod]
         uses: navikt/sif-gha-workflows/.github/workflows/trivy.yml@main
         permissions:
             contents: write

--- a/.github/workflows/.run-all-tests.yml
+++ b/.github/workflows/.run-all-tests.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node.js environment
               uses: actions/setup-node@v6.4.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: "pnpm"
 
             - name: Install dependencies

--- a/.github/workflows/.test-app.yml
+++ b/.github/workflows/.test-app.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       # Installer avhengigheter

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,7 +13,7 @@ jobs:
 
             - uses: actions/setup-node@v6.4.0
               with:
-                  node-version: 22
+                  node-version: 24
 
             - uses: pnpm/action-setup@v6
             - run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-veileder-app-to-dev.yml
+++ b/.github/workflows/deploy-veileder-app-to-dev.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - name: Install Dependencies

--- a/.github/workflows/test-changed-apps.yml
+++ b/.github/workflows/test-changed-apps.yml
@@ -321,7 +321,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies

--- a/apps-intern/ungdomsytelse-veileder/package.json
+++ b/apps-intern/ungdomsytelse-veileder/package.json
@@ -43,7 +43,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",
         "@navikt/sif-common-core-ds": "workspace:*",

--- a/apps/aktivitetspenger-innsyn/package.json
+++ b/apps/aktivitetspenger-innsyn/package.json
@@ -29,7 +29,7 @@
         "@navikt/fnrvalidator": "2.2.1",
         "@navikt/k9-brukerdialog-prosessering-api": "workspace:*",
         "@navikt/k9-sak-innsyn-api": "workspace:*",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-core-ds": "workspace:*",
         "@navikt/sif-common-env": "workspace:*",

--- a/apps/dine-pleiepenger/package.json
+++ b/apps/dine-pleiepenger/package.json
@@ -22,7 +22,7 @@
         "@navikt/aksel-icons": "8.11.0",
         "@navikt/appstatus-react-ds": "workspace:*",
         "@navikt/k9-sak-innsyn-api": "workspace:*",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/next-logger": "5.0.0",
         "@navikt/oasis": "4.1.4",
         "@navikt/sif-app-register": "workspace:*",

--- a/apps/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn/package.json
+++ b/apps/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn/package.json
@@ -49,7 +49,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/endringsmelding-pleiepenger/package.json
+++ b/apps/endringsmelding-pleiepenger/package.json
@@ -77,7 +77,7 @@
     "devDependencies": {
         "@axe-core/playwright": "4.11.3",
         "@navikt/ds-tailwind": "8.11.0",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@playwright/test": "1.60.0",
         "@sentry/vite-plugin": "5.3.0",
         "@sif/eslint-config": "workspace:*",

--- a/apps/omsorgsdager-aleneomsorg-dialog/package.json
+++ b/apps/omsorgsdager-aleneomsorg-dialog/package.json
@@ -34,7 +34,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/omsorgsdager-kalkulator/package.json
+++ b/apps/omsorgsdager-kalkulator/package.json
@@ -18,7 +18,7 @@
         "@navikt/ds-css": "8.11.0",
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "classnames": "2.5.1",
         "csp-header": "6.3.1",
         "date-fns": "4.3.0",

--- a/apps/omsorgspengerutbetaling-arbeidstaker-soknad/package.json
+++ b/apps/omsorgspengerutbetaling-arbeidstaker-soknad/package.json
@@ -49,7 +49,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/omsorgspengerutbetaling-soknad/package.json
+++ b/apps/omsorgspengerutbetaling-soknad/package.json
@@ -49,7 +49,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/omsorgspengesoknad/package.json
+++ b/apps/omsorgspengesoknad/package.json
@@ -34,7 +34,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/opplaringspenger-soknad/package.json
+++ b/apps/opplaringspenger-soknad/package.json
@@ -47,7 +47,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/pleiepenger-i-livets-sluttfase-soknad/package.json
+++ b/apps/pleiepenger-i-livets-sluttfase-soknad/package.json
@@ -39,7 +39,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/pleiepenger-sykt-barn/package.json
+++ b/apps/pleiepenger-sykt-barn/package.json
@@ -29,7 +29,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/sif-ettersending/package.json
+++ b/apps/sif-ettersending/package.json
@@ -27,7 +27,7 @@
         "@navikt/ds-react": "8.11.0",
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/ungdomsytelse-deltaker/package.json
+++ b/apps/ungdomsytelse-deltaker/package.json
@@ -37,7 +37,7 @@
         "@navikt/ds-tailwind": "8.11.0",
         "@navikt/k9-brukerdialog-prosessering-api": "workspace:*",
         "@navikt/k9-sak-innsyn-api": "workspace:*",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-app-register": "workspace:*",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",

--- a/apps/ungdomsytelse-deltaker/src/analytics/analytics.tsx
+++ b/apps/ungdomsytelse-deltaker/src/analytics/analytics.tsx
@@ -45,7 +45,7 @@ export const [AnalyticsProvider, useAnalyticsInstance] = constate((props: Props)
             const timeoutPromise = new Promise((resolve) => setTimeout(() => resolve(null), maxAwaitTime));
             const logPromise = new Promise((resolve) => {
                 const eventProps = { ...eventProperties, applikasjon: applicationKey };
-                logger(eventName, eventProps).catch(() => {
+                logger.custom(eventName, eventProps).catch(() => {
                     resolve(true);
                 });
             });

--- a/apps/ungdomsytelse-deltaker/src/analytics/analytics.tsx
+++ b/apps/ungdomsytelse-deltaker/src/analytics/analytics.tsx
@@ -45,9 +45,10 @@ export const [AnalyticsProvider, useAnalyticsInstance] = constate((props: Props)
             const timeoutPromise = new Promise((resolve) => setTimeout(() => resolve(null), maxAwaitTime));
             const logPromise = new Promise((resolve) => {
                 const eventProps = { ...eventProperties, applikasjon: applicationKey };
-                logger.custom(eventName, eventProps).catch(() => {
-                    resolve(true);
-                });
+                logger
+                    .custom(eventName, eventProps)
+                    .then(resolve)
+                    .catch(() => resolve(true));
             });
             return Promise.race([timeoutPromise, logPromise]);
         }

--- a/packages/sif-common-analytics/package.json
+++ b/packages/sif-common-analytics/package.json
@@ -10,7 +10,7 @@
         "lint:tsc": "tsc --noEmit"
     },
     "dependencies": {
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "constate": "3.3.3"
     },
     "devDependencies": {

--- a/packages/sif-common-analytics/src/analytics.ts
+++ b/packages/sif-common-analytics/src/analytics.ts
@@ -67,9 +67,12 @@ export const [AnalyticsProvider, useAnalyticsInstance] = constate((props: Props)
             const timeoutPromise = new Promise((resolve) => setTimeout(() => resolve(null), maxAwaitTime));
             const logPromise = new Promise((resolve) => {
                 const eventProps = { ...eventProperties, app: applicationKey, applikasjon: applicationKey, apiKey };
-                logger.custom(eventName, eventProps).catch(() => {
-                    resolve(true);
-                });
+                logger
+                    .custom(eventName, eventProps)
+                    .then(resolve)
+                    .catch(() => {
+                        resolve(true);
+                    });
             });
             return Promise.race([timeoutPromise, logPromise]);
         }

--- a/packages/sif-common-analytics/src/analytics.ts
+++ b/packages/sif-common-analytics/src/analytics.ts
@@ -67,7 +67,7 @@ export const [AnalyticsProvider, useAnalyticsInstance] = constate((props: Props)
             const timeoutPromise = new Promise((resolve) => setTimeout(() => resolve(null), maxAwaitTime));
             const logPromise = new Promise((resolve) => {
                 const eventProps = { ...eventProperties, app: applicationKey, applikasjon: applicationKey, apiKey };
-                logger(eventName, eventProps).catch(() => {
+                logger.custom(eventName, eventProps).catch(() => {
                     resolve(true);
                 });
             });

--- a/packages/sif-common-sentry/package.json
+++ b/packages/sif-common-sentry/package.json
@@ -48,6 +48,6 @@
         "vitest": "4.1.7"
     },
     "peerDependencies": {
-        "axios": "1.16.1"
+        "axios": "^1.16.1"
     }
 }

--- a/packages/sif-common-sentry/package.json
+++ b/packages/sif-common-sentry/package.json
@@ -48,6 +48,6 @@
         "vitest": "4.1.7"
     },
     "peerDependencies": {
-        "axios": "^1.16.1"
+        "axios": "1.16.1"
     }
 }

--- a/packages/sif-common-soknad-ds/package.json
+++ b/packages/sif-common-soknad-ds/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@navikt/appstatus-react-ds": "workspace:*",
         "@navikt/fnrvalidator": "2.2.1",
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/sif-common-analytics": "workspace:*",
         "@navikt/sif-common-api": "workspace:*",
         "classnames": "2.5.1",

--- a/packages/ung-common/package.json
+++ b/packages/ung-common/package.json
@@ -37,7 +37,7 @@
     },
     "peerDependencies": {
         "@navikt/ds-react": "*",
-        "axios": "1.16.1",
+        "axios": "^1.16.1",
         "dayjs": "*",
         "react": "*",
         "react-dom": "*",

--- a/packages/ung-common/package.json
+++ b/packages/ung-common/package.json
@@ -37,7 +37,7 @@
     },
     "peerDependencies": {
         "@navikt/ds-react": "*",
-        "axios": "^1.16.1",
+        "axios": "1.16.1",
         "dayjs": "*",
         "react": "*",
         "react-dom": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -329,8 +329,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/k9-sak-innsyn-api
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -673,8 +673,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/k9-sak-innsyn-api
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/next-logger':
         specifier: 5.0.0
         version: 5.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(pino@10.3.1)
@@ -860,8 +860,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -1156,8 +1156,8 @@ importers:
         specifier: 8.11.0
         version: 8.11.0
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -1288,8 +1288,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -1490,8 +1490,8 @@ importers:
         specifier: 8.11.0
         version: 8.11.0
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       classnames:
         specifier: 2.5.1
         version: 2.5.1
@@ -1608,8 +1608,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -1819,8 +1819,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -2024,8 +2024,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -2425,8 +2425,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -2651,8 +2651,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -2859,8 +2859,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -3266,8 +3266,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -3559,8 +3559,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/k9-sak-innsyn-api
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-app-register':
         specifier: workspace:*
         version: link:../../packages/sif-app-register
@@ -4177,8 +4177,8 @@ importers:
   packages/sif-common-analytics:
     dependencies:
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       constate:
         specifier: 3.3.3
         version: 3.3.3(react@19.2.6)
@@ -4846,8 +4846,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/sif-common-analytics':
         specifier: workspace:*
         version: link:../sif-common-analytics
@@ -5838,8 +5838,8 @@ importers:
   server:
     dependencies:
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/oasis':
         specifier: 4.1.4
         version: 4.1.4
@@ -5905,8 +5905,8 @@ importers:
   server-ungdomsytelse-veileder:
     dependencies:
       '@navikt/nav-dekoratoren-moduler':
-        specifier: 3.7.1
-        version: 3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        specifier: 4.1.1
+        version: 4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@navikt/oasis':
         specifier: 4.1.4
         version: 4.1.4
@@ -8108,6 +8108,10 @@ packages:
   '@navikt/aksel-icons@8.11.0':
     resolution: {integrity: sha512-enprSpDl7j4yDEAtVtp/BPby2McZKtgXIgarTVDeZ0pmiqnYbXFyCTgzl/ZMg2/EV+hd2DXpLsKzU73PDljpmw==, tarball: https://npm.pkg.github.com/download/@navikt/aksel-icons/8.11.0/964e1e0e34af7007f43b4522246daea582e44952}
 
+  '@navikt/analytics-types@0.0.9':
+    resolution: {integrity: sha512-bopCvqEogyFcmrJiBxK/Mr25d6yPKF7GR36MGrJqiHCPJYf1rDu6lK4cpooTG4Q//D/1xTkHRom8ZH5BI6dTew==, tarball: https://npm.pkg.github.com/download/@navikt/analytics-types/0.0.9/5919241a6dbb782eb101fff3234ce5c36d16e942}
+    engines: {node: '>=20.0.0', npm: '>=9.0.0'}
+
   '@navikt/ds-css@8.11.0':
     resolution: {integrity: sha512-UxPVWtZC9JW1vho0JFdxh9XmQpiKVQgM2+HhE5st5h8W5AUKOgzrSUkSjQQNEdeAg1RhWhJ2Jwu3W2rC4VZS1Q==, tarball: https://npm.pkg.github.com/download/@navikt/ds-css/8.11.0/888861af213f1f01d1becab42fe59810b6dba2be}
 
@@ -8130,15 +8134,12 @@ packages:
   '@navikt/fnrvalidator@2.2.1':
     resolution: {integrity: sha512-R6x3MBFC0E/B7oTs+P2jAP+ym7+d6cwSpDsLeMja9IwPpJq3HV/OClFBVWm9fJZPmXfumKRMGy6gqsQPj90ftg==, tarball: https://npm.pkg.github.com/download/@navikt/fnrvalidator/2.2.1/37ed0feb23a7525139ad5512684ff6b0977112c6}
 
-  '@navikt/nav-dekoratoren-moduler@3.7.1':
-    resolution: {integrity: sha512-MQLxR4uoADCd6i0hFnWHN/XLPevEfxkBK9yEgbtcY0v2gsj69nALH/7DvTKqSxqRovxOHibVa7mZKZEBAMRBvg==, tarball: https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/3.7.1/09490a131cedd7779e35d413d20c36bd01ef57a0}
+  '@navikt/nav-dekoratoren-moduler@4.1.1':
+    resolution: {integrity: sha512-OyCVWavseiyGQwk8xHb6vShJtL+kOO/HIJe65QIsWrk85JV/ZeirB1/B4seA9klor1Zi9IvqyJkzl+nsJVZq9g==, tarball: https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/4.1.1/14a1ab3742f4564e5fd921553b5cce65f534edf1}
     engines: {node: 24.x}
     peerDependencies:
       html-react-parser: '>=5.x'
       react: '>=17.x'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   '@navikt/next-logger@5.0.0':
     resolution: {integrity: sha512-VQ2VM/k5uDYnb7BYG3ITJZgMZq8B3TECOnhdvNOQeltJyy8+KQzGqLsrYajKPWuUiPuLjYFk0HbU2W22onB9mQ==, tarball: https://npm.pkg.github.com/download/@navikt/next-logger/5.0.0/510dccac519d1227515e4c8a8268570d90305b3e}
@@ -20226,6 +20227,8 @@ snapshots:
 
   '@navikt/aksel-icons@8.11.0': {}
 
+  '@navikt/analytics-types@0.0.9': {}
+
   '@navikt/ds-css@8.11.0': {}
 
   '@navikt/ds-react@8.11.0(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
@@ -20247,12 +20250,12 @@ snapshots:
 
   '@navikt/fnrvalidator@2.2.1': {}
 
-  '@navikt/nav-dekoratoren-moduler@3.7.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
+  '@navikt/nav-dekoratoren-moduler@4.1.1(html-react-parser@6.1.2(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
+      '@navikt/analytics-types': 0.0.9
       csp-header: 6.3.1
       html-react-parser: 6.1.2(@types/react@19.2.15)(react@19.2.6)
       js-cookie: 3.0.5
-    optionalDependencies:
       react: 19.2.6
 
   '@navikt/next-logger@5.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(pino@10.3.1)':

--- a/server-ungdomsytelse-veileder/package.json
+++ b/server-ungdomsytelse-veileder/package.json
@@ -7,7 +7,7 @@
         "build": "esbuild src/index.ts --bundle --platform=node --outfile=dist/index.js --format=cjs"
     },
     "dependencies": {
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/oasis": "4.1.4",
         "@navikt/sif-common-env": "workspace:*",
         "csp-header": "6.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
         "build": "esbuild src/index.ts --bundle --platform=node --outfile=dist/index.js --format=cjs"
     },
     "dependencies": {
-        "@navikt/nav-dekoratoren-moduler": "3.7.1",
+        "@navikt/nav-dekoratoren-moduler": "4.1.1",
         "@navikt/oasis": "4.1.4",
         "@navikt/sif-common-env": "workspace:*",
         "csp-header": "6.3.1",


### PR DESCRIPTION
### Behov / Bakgrunn

`@navikt/nav-dekoratoren-moduler` er oppgradert fra v3 til v4. Den nye versjonen krever Node 24, så workflow-oppsett måtte være kompatibelt for å unngå feil i CI.

### Løsning

Oppgraderte `@navikt/nav-dekoratoren-moduler` til `4.1.1` i relevante workspaces og oppdaterte tilhørende kode der API-et i dekoratørmodulen har endret seg (analytics-logging via `logger.custom(...)`).

### Andre endringer

- Oppdaterte GitHub Actions-workflows til Node 24 for å matche engine-kravet til dekoratørpakken.
- Justerte peerDependencies for `axios` til semver-range i berørte pakker for å unngå unødvendige peer-konflikter.
- Oppdaterte `pnpm-lock.yaml` i tråd med avhengighetsendringene.