### PR TITLE
ReadMore og lenker til forskrift og lover i oppgaver og varsler

### DIFF
--- a/apps/ungdomsytelse-deltaker/src/apps/innsyn/utils/__tests__/logUtils.test.ts
+++ b/apps/ungdomsytelse-deltaker/src/apps/innsyn/utils/__tests__/logUtils.test.ts
@@ -1,5 +1,5 @@
 import { logUtils } from '@innsyn/utils/logUtils';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { DeltakelsePeriode } from '@shared/types/DeltakelsePeriode';
 import { ParsedOppgavetype, SøkYtelseOppgave } from '@sif/api/ung-brukerdialog';
 import { UtvidetKontonummerInfo } from '@sif/api/ung-deltaker';
@@ -28,7 +28,8 @@ describe('logUtils.getSøknadInnsendingMeta', () => {
     };
 
     const mockOppgave: SøkYtelseOppgave = {
-        oppgavetype: ParsedOppgavetype.SØK_YTELSE,
+        oppgavetype: OppgaveType.SØK_YTELSE,
+        parsedOppgavetype: ParsedOppgavetype.SØK_YTELSE,
         status: OppgaveStatus.ULØST,
         opprettetDato: dayjs().subtract(1, 'day').toDate(),
         oppgaveReferanse: 'test-ref',

--- a/apps/ungdomsytelse-deltaker/src/apps/innsyn/utils/deltakelseUtils.ts
+++ b/apps/ungdomsytelse-deltaker/src/apps/innsyn/utils/deltakelseUtils.ts
@@ -33,7 +33,7 @@ export const erDeltakelseStartet = (deltakelsePeriode: DeltakelsePeriode): boole
 export const harRapportertInntekt = (oppgaver: Oppgave[]): boolean => {
     return oppgaver.some(
         (o) =>
-            o.oppgavetype === ParsedOppgavetype.RAPPORTER_INNTEKT &&
+            o.parsedOppgavetype === ParsedOppgavetype.RAPPORTER_INNTEKT &&
             o.status !== OppgaveStatus.ULØST &&
             o.respons?.arbeidstakerOgFrilansInntekt !== undefined,
     );

--- a/apps/ungdomsytelse-deltaker/src/apps/innsyn/utils/logUtils.ts
+++ b/apps/ungdomsytelse-deltaker/src/apps/innsyn/utils/logUtils.ts
@@ -29,7 +29,7 @@ const getDeltakelsePeriodeMeta = (deltakelse: DeltakelsePeriode, oppgaver: Oppga
     const harStartet = dayjs(deltakelse.programPeriode.from).isBefore(dayjs());
     const erAvsluttet = dayjs(deltakelse.programPeriode.to).isBefore(dayjs());
 
-    const søkYtelseOppgave = oppgaver.find((oppgave) => oppgave.oppgavetype === ParsedOppgavetype.SØK_YTELSE);
+    const søkYtelseOppgave = oppgaver.find((oppgave) => oppgave.parsedOppgavetype === ParsedOppgavetype.SØK_YTELSE);
     return {
         harSøkt,
         harStartet,
@@ -44,19 +44,20 @@ const getDeltakelsePeriodeMeta = (deltakelse: DeltakelsePeriode, oppgaver: Oppga
         antallAvbrutteOppgaver: oppgaver.filter((oppgave) => oppgave.status === OppgaveStatus.AVBRUTT).length,
         harSluttdato: deltakelse.programPeriode.to !== undefined,
         antallEndretStartdatoOppgaver: oppgaver.filter(
-            (oppgave) => oppgave.oppgavetype === ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO,
+            (oppgave) => oppgave.parsedOppgavetype === ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO,
         ).length,
         antallEndretSluttdatoOppgaver: oppgaver.filter(
-            (oppgave) => oppgave.oppgavetype === ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO,
+            (oppgave) => oppgave.parsedOppgavetype === ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO,
         ).length,
         antallAvvikInntektOppgaver: oppgaver.filter(
-            (oppgave) => oppgave.oppgavetype === ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
+            (oppgave) => oppgave.parsedOppgavetype === ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
         ).length,
         antallRapporterInntektOppgaver: oppgaver.filter(
-            (oppgave) => oppgave.oppgavetype === ParsedOppgavetype.RAPPORTER_INNTEKT,
+            (oppgave) => oppgave.parsedOppgavetype === ParsedOppgavetype.RAPPORTER_INNTEKT,
         ).length,
-        antallSøkYtelseOppgaver: oppgaver.filter((oppgave) => oppgave.oppgavetype === ParsedOppgavetype.SØK_YTELSE)
-            .length,
+        antallSøkYtelseOppgaver: oppgaver.filter(
+            (oppgave) => oppgave.parsedOppgavetype === ParsedOppgavetype.SØK_YTELSE,
+        ).length,
     };
 };
 
@@ -99,7 +100,7 @@ export const getOppgaveBekreftelseMeta = (
     uttalelse: ungdomsytelse.UngdomsytelseOppgaveUttalelseDto,
 ) => {
     return {
-        oppgavetype: oppgave.oppgavetype,
+        oppgavetype: oppgave.parsedOppgavetype,
         antallDagerMellomOpprettetOgBesvart: dayjs().diff(oppgave.opprettetDato, 'day'),
         antallMinutterMellomOpprettetOgBesvart: dayjs().diff(oppgave.opprettetDato, 'minutes'),
         harUttalelse: uttalelse.harUttalelse,

--- a/apps/ungdomsytelse-deltaker/src/apps/søknad/SøknadApp.tsx
+++ b/apps/ungdomsytelse-deltaker/src/apps/søknad/SøknadApp.tsx
@@ -40,7 +40,7 @@ const SøknadApp = () => {
         return <HentDeltakerErrorPage error={text('søknadApp.loading.error')} />;
     }
 
-    const søknadOppgave = oppgaver.find((o) => o.oppgavetype === ParsedOppgavetype.SØK_YTELSE);
+    const søknadOppgave = oppgaver.find((o) => o.parsedOppgavetype === ParsedOppgavetype.SØK_YTELSE);
 
     if (!søknadOppgave) {
         return <IngenSendSøknadOppgave />;

--- a/apps/ungdomsytelse-deltaker/src/components/deltaker-info-loader/DeltakerInfoLoader.tsx
+++ b/apps/ungdomsytelse-deltaker/src/components/deltaker-info-loader/DeltakerInfoLoader.tsx
@@ -94,7 +94,9 @@ const DeltakerInfoLoader = () => {
 
     const deltakelsePeriode = deltakelsePerioder.data[0];
 
-    const sendSøknadOppgave = oppgaver.data.find((oppgave) => oppgave.oppgavetype === ParsedOppgavetype.SØK_YTELSE);
+    const sendSøknadOppgave = oppgaver.data.find(
+        (oppgave) => oppgave.parsedOppgavetype === ParsedOppgavetype.SØK_YTELSE,
+    );
 
     const deltakerHarSøkt =
         deltakelsePeriode.søktTidspunkt !== undefined || (oppgaver.data.length > 0 && sendSøknadOppgave === undefined);

--- a/packages/sif-api/src/api/parse-utils/__tests__/parseOppgaverElement.test.ts
+++ b/packages/sif-api/src/api/parse-utils/__tests__/parseOppgaverElement.test.ts
@@ -27,7 +27,7 @@ describe('parseOppgaverElement – BEKREFT_OPPHOR_VED_MAKSDATO', () => {
         ]);
 
         const oppgave = result as OpphorVedMaksdatoOppgave;
-        expect(oppgave.oppgavetype).toBe(ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO);
+        expect(oppgave.parsedOppgavetype).toBe(ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO);
         expect(oppgave.oppgavetypeData.maksdato).toEqual(new Date('2026-06-30'));
     });
 

--- a/packages/sif-api/src/api/parse-utils/parseOppgaverElement.ts
+++ b/packages/sif-api/src/api/parse-utils/parseOppgaverElement.ts
@@ -92,11 +92,12 @@ const parseRapportertInntektRespons = (respons?: any): RapportertInntektRespons 
     return undefined;
 };
 
-const getOppgaveBaseProps = (oppgave: BrukerdialogOppgaveDto): Omit<ParsedOppgaveBase, 'oppgavetype'> => {
+const getOppgaveBaseProps = (oppgave: BrukerdialogOppgaveDto): Omit<ParsedOppgaveBase, 'parsedOppgavetype'> => {
     const løstDato = oppgave.løstDato ? dayjs.utc(oppgave.løstDato).toDate() : undefined;
     const opprettetDato = dayjs.utc(oppgave.opprettetDato).toDate();
     const svarfrist = oppgave.frist ? dayjs.utc(oppgave.frist).toDate() : ISODateToDate('2099-01-01');
     return {
+        oppgavetype: oppgave.oppgavetype,
         oppgaveReferanse: oppgave.oppgaveReferanse,
         status: getOppgaveStatusEnum(oppgave.status),
         opprettetDato,

--- a/packages/sif-api/src/api/parse-utils/parseOppgaverElement.ts
+++ b/packages/sif-api/src/api/parse-utils/parseOppgaverElement.ts
@@ -114,7 +114,7 @@ const getEndretSluttdatoOppgave = (
     if (forrigeSluttdato) {
         return {
             ...getOppgaveBaseProps(oppgave),
-            oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO,
+            parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO,
             oppgavetypeData: {
                 forrigeSluttdato: ISODateToDate(forrigeSluttdato),
                 nySluttdato: ISODateToDate(nySluttdato),
@@ -124,7 +124,7 @@ const getEndretSluttdatoOppgave = (
     }
     return {
         ...getOppgaveBaseProps(oppgave),
-        oppgavetype: ParsedOppgavetype.BEKREFT_MELDT_UT,
+        parsedOppgavetype: ParsedOppgavetype.BEKREFT_MELDT_UT,
         oppgavetypeData: {
             sluttdato: ISODateToDate(nySluttdato),
         },
@@ -138,7 +138,7 @@ const getEndretStartdatoOppgave = (
     forrigeStartdato: string,
 ): EndretStartdatoOppgave => ({
     ...getOppgaveBaseProps(oppgave),
-    oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO,
     oppgavetypeData: {
         forrigeStartdato: ISODateToDate(forrigeStartdato),
         nyStartdato: ISODateToDate(nyStartdato),
@@ -172,7 +172,7 @@ const getOppgaveFraEndretPeriodeOppgave = (oppgave: BrukerdialogOppgaveDto): Opp
     if (endringer.length === 1 && endringer.includes(PeriodeEndringType.FJERNET_PERIODE)) {
         const fjernetPeriodeOppgave: FjernetPeriodeOppgave = {
             ...getOppgaveBaseProps(oppgave),
-            oppgavetype: ParsedOppgavetype.BEKREFT_FJERNET_PERIODE,
+            parsedOppgavetype: ParsedOppgavetype.BEKREFT_FJERNET_PERIODE,
             respons: parseSvarPåVarselRespons(oppgave.respons),
         };
         return fjernetPeriodeOppgave;
@@ -190,7 +190,7 @@ const getOppgaveFraEndretPeriodeOppgave = (oppgave: BrukerdialogOppgaveDto): Opp
     ) {
         const endretStartOgSluttdatoOppgave: EndretStartOgSluttdatoOppgave = {
             ...getOppgaveBaseProps(oppgave),
-            oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO,
+            parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO,
             oppgavetypeData: {
                 forrigePeriode: mapPeriodeDtoToOpenDateRange({
                     fomDato: forrigePeriode.fomDato,
@@ -220,7 +220,7 @@ export const parseOppgaverElement = (
                 const bostedData = oppgave.oppgavetypeData as BekreftBostedOppgavetypeDataDto;
                 const bostedVilkårOppgave: BostedVilkårOppgave = {
                     ...getOppgaveBaseProps(oppgave),
-                    oppgavetype: ParsedOppgavetype.BEKREFT_BOSTED,
+                    parsedOppgavetype: ParsedOppgavetype.BEKREFT_BOSTED,
                     oppgavetypeData: {
                         periode: {
                             from: ISODateToDate(bostedData.fom),
@@ -249,7 +249,7 @@ export const parseOppgaverElement = (
                 const avvikRegisterinntektData = oppgave.oppgavetypeData as KontrollerRegisterinntektOppgavetypeDataDto;
                 const avvikRegisterinntektOppgave: AvvikRegisterinntektOppgave = {
                     ...getOppgaveBaseProps(oppgave),
-                    oppgavetype: ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
+                    parsedOppgavetype: ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
                     oppgavetypeData: {
                         ...avvikRegisterinntektData,
                         fraOgMed: ISODateToDate(avvikRegisterinntektData.fraOgMed),
@@ -266,7 +266,7 @@ export const parseOppgaverElement = (
                 const rapporterInntektOppgave: RapporterInntektOppgave = {
                     ...getOppgaveBaseProps(oppgave),
                     oppgaveYtelsetype,
-                    oppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT,
+                    parsedOppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT,
                     oppgavetypeData: {
                         fraOgMed: ISODateToDate(rapporterInntektData.fraOgMed),
                         tilOgMed: ISODateToDate(rapporterInntektData.tilOgMed),
@@ -281,7 +281,7 @@ export const parseOppgaverElement = (
                 const { fomDato } = oppgave.oppgavetypeData as SøkYtelseOppgavetypeDataDto;
                 const sendSøknadOppgave: Oppgave = {
                     ...getOppgaveBaseProps(oppgave),
-                    oppgavetype: ParsedOppgavetype.SØK_YTELSE,
+                    parsedOppgavetype: ParsedOppgavetype.SØK_YTELSE,
                     oppgavetypeData: {
                         fomDato: ISODateToDate(fomDato),
                     },
@@ -292,7 +292,7 @@ export const parseOppgaverElement = (
                 const { maxDato, sluttdato } = oppgave.oppgavetypeData as BekreftOpphorVedMaksdatoOppgavetypeDataDto;
                 const bekreftOpphorVedMaksdatoOppgave: Oppgave = {
                     ...getOppgaveBaseProps(oppgave),
-                    oppgavetype: ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO,
+                    parsedOppgavetype: ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO,
                     oppgavetypeData: {
                         sluttdato: ISODateToDate(sluttdato),
                         maksdato: ISODateToDate(maxDato),

--- a/packages/sif-api/src/types/Oppgave.ts
+++ b/packages/sif-api/src/types/Oppgave.ts
@@ -32,7 +32,7 @@ export type SvarPåVarselRespons = SvarPåVarselDto & {
 };
 export interface ParsedOppgaveBase extends Omit<
     BrukerdialogOppgaveDto,
-    'oppgavetype' | 'opprettetDato' | 'løstDato' | 'åpnetDato' | 'lukketDato' | 'oppgavetypeData' | 'frist' | 'respons'
+    'opprettetDato' | 'løstDato' | 'åpnetDato' | 'lukketDato' | 'oppgavetypeData' | 'frist' | 'respons'
 > {
     oppgaveReferanse: string;
     parsedOppgavetype: ParsedOppgavetype;

--- a/packages/sif-api/src/types/Oppgave.ts
+++ b/packages/sif-api/src/types/Oppgave.ts
@@ -35,7 +35,7 @@ export interface ParsedOppgaveBase extends Omit<
     'oppgavetype' | 'opprettetDato' | 'løstDato' | 'åpnetDato' | 'lukketDato' | 'oppgavetypeData' | 'frist' | 'respons'
 > {
     oppgaveReferanse: string;
-    oppgavetype: ParsedOppgavetype;
+    parsedOppgavetype: ParsedOppgavetype;
     opprettetDato: Date;
     status: OppgaveStatus;
     løstDato?: Date;
@@ -49,7 +49,7 @@ export interface ParsedRapportertInntektOppgave extends ParsedOppgaveBase {
 }
 
 export interface AvvikRegisterinntektOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT;
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT;
     oppgavetypeData: {
         fraOgMed: Date;
         tilOgMed: Date;
@@ -60,7 +60,7 @@ export interface AvvikRegisterinntektOppgave extends ParsedOppgaveBase {
 }
 
 export interface EndretStartdatoOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO;
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO;
     oppgavetypeData: {
         forrigeStartdato: Date;
         nyStartdato: Date;
@@ -68,7 +68,7 @@ export interface EndretStartdatoOppgave extends ParsedOppgaveBase {
     respons?: SvarPåVarselRespons;
 }
 export interface BostedVilkårOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.BEKREFT_BOSTED;
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_BOSTED;
     oppgavetypeData: {
         periode: DateRange;
         erBosattITrondheim: boolean;
@@ -77,7 +77,7 @@ export interface BostedVilkårOppgave extends ParsedOppgaveBase {
 }
 
 export interface EndretSluttdatoOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO;
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO;
     oppgavetypeData: {
         forrigeSluttdato: Date;
         nySluttdato: Date;
@@ -86,7 +86,7 @@ export interface EndretSluttdatoOppgave extends ParsedOppgaveBase {
 }
 
 export interface MeldtUtOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.BEKREFT_MELDT_UT;
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_MELDT_UT;
     oppgavetypeData: {
         sluttdato: Date;
     };
@@ -94,7 +94,7 @@ export interface MeldtUtOppgave extends ParsedOppgaveBase {
 }
 
 export interface EndretStartOgSluttdatoOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO;
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO;
     oppgavetypeData: {
         forrigePeriode: OpenDateRange;
         nyPeriode: DateRange;
@@ -103,12 +103,12 @@ export interface EndretStartOgSluttdatoOppgave extends ParsedOppgaveBase {
 }
 
 export interface FjernetPeriodeOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.BEKREFT_FJERNET_PERIODE;
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_FJERNET_PERIODE;
     respons?: SvarPåVarselRespons;
 }
 
 export interface OpphorVedMaksdatoOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO;
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO;
     oppgavetypeData: {
         maksdato: Date;
         sluttdato: Date;
@@ -130,7 +130,7 @@ export type BekreftelseOppgave =
 
 export interface RapporterInntektOppgave extends ParsedRapportertInntektOppgave {
     oppgaveYtelsetype: OppgaveYtelsetype;
-    oppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT;
+    parsedOppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT;
     oppgavetypeData: {
         fraOgMed: Date;
         tilOgMed: Date;
@@ -139,7 +139,7 @@ export interface RapporterInntektOppgave extends ParsedRapportertInntektOppgave 
 }
 
 export interface SøkYtelseOppgave extends ParsedOppgaveBase {
-    oppgavetype: ParsedOppgavetype.SØK_YTELSE;
+    parsedOppgavetype: ParsedOppgavetype.SØK_YTELSE;
     oppgavetypeData: {
         fomDato: Date;
     };

--- a/packages/ung-innsyn/src/components/readmore/RegelverkOgInnsynReadMore.tsx
+++ b/packages/ung-innsyn/src/components/readmore/RegelverkOgInnsynReadMore.tsx
@@ -2,11 +2,13 @@ import { BodyLong, Link, List, ReadMore, VStack } from '@navikt/ds-react';
 
 import { UngUiText, useUngUiIntl } from '../../i18n';
 import { Lovlenke } from '../../modules/oppgavepaneler/utils/lovverk';
+import { OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 
 interface Props {
     lenker: Lovlenke[];
+    ytelsetype: OppgaveYtelsetype;
 }
-export const RegelverkOgInnsynReadMore = ({ lenker }: Props) => {
+export const RegelverkOgInnsynReadMore = ({ lenker, ytelsetype }: Props) => {
     const { text } = useUngUiIntl();
 
     if (lenker.length === 0) {
@@ -16,7 +18,9 @@ export const RegelverkOgInnsynReadMore = ({ lenker }: Props) => {
     return (
         <ReadMore header={text('@ungInnsyn.regelverkOgInnsyn.readMore.tittel')}>
             <BodyLong>
-                <UngUiText id="@ungInnsyn.regelverkOgInnsyn.readMore.tekst.1" />
+                {ytelsetype === OppgaveYtelsetype.UNGDOMSYTELSE
+                    ? text('@ungInnsyn.regelverkOgInnsyn.readMore.ungdomsytelse')
+                    : text('@ungInnsyn.regelverkOgInnsyn.readMore.aktivitetspenger')}
             </BodyLong>
             <VStack gap="space-24">
                 <List>

--- a/packages/ung-innsyn/src/components/readmore/RegelverkOgInnsynReadMore.tsx
+++ b/packages/ung-innsyn/src/components/readmore/RegelverkOgInnsynReadMore.tsx
@@ -1,9 +1,18 @@
 import { BodyLong, Link, List, ReadMore, VStack } from '@navikt/ds-react';
 
 import { UngUiText, useUngUiIntl } from '../../i18n';
+import { Lovlenke } from '../../modules/oppgavepaneler/utils/lovverk';
 
-export const RegelverkOgInnsynReadMore = () => {
+interface Props {
+    lenker: Lovlenke[];
+}
+export const RegelverkOgInnsynReadMore = ({ lenker }: Props) => {
     const { text } = useUngUiIntl();
+
+    if (lenker.length === 0) {
+        return null;
+    }
+
     return (
         <ReadMore header={text('@ungInnsyn.regelverkOgInnsyn.readMore.tittel')}>
             <BodyLong>
@@ -11,16 +20,13 @@ export const RegelverkOgInnsynReadMore = () => {
             </BodyLong>
             <VStack gap="space-24">
                 <List>
-                    <List.Item>
-                        <Link href="https://lovdata.no/dokument/NL/lov/2004-12-10-76">
-                            <UngUiText id="@ungInnsyn.regelverkOgInnsyn.readMore.paragraf" />
-                        </Link>
-                    </List.Item>
-                    <List.Item>
-                        <Link href="https://lovdata.no/dokument/LTI/forskrift/2025-06-20-1182">
-                            <UngUiText id="@ungInnsyn.regelverkOgInnsyn.readMore.forskrift" />
-                        </Link>
-                    </List.Item>
+                    {lenker.map((lenke) => (
+                        <List.Item key={lenke.url}>
+                            <Link href={lenke.url} target="_blank" rel="noopener noreferrer">
+                                {lenke.tekst}
+                            </Link>
+                        </List.Item>
+                    ))}
                 </List>
                 <BodyLong>
                     <UngUiText

--- a/packages/ung-innsyn/src/modules/oppgavebekreftelse/OppgavebekreftelseParts.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavebekreftelse/OppgavebekreftelseParts.tsx
@@ -5,13 +5,15 @@ import { OppgaveResponsDto, OppgaveStatus } from '@navikt/ung-brukerdialog-api';
 import { useEffect, useRef } from 'react';
 
 import { ForsideLenkeButton, OppgaveStatusInfo } from '../../components';
-import { RegelverkOgInnsynReadMore } from '../../components/readmore/RegelverkOgInnsynReadMore';
+
 import { UngUiText, useUngUiIntl } from '../../i18n';
 import { useOppgavePage } from '../../pages/hooks/useOppgavePage';
 import { UttalelseSvaralternativer } from '../../types';
 import { getSvaralternativer, getTilbakemeldingFritekstLabel, getTilbakemeldingSpørsmål } from '../../utils/textUtils';
 import { UtalelseForm } from '../forms/uttalelse-form/UtalelseForm';
 import { useOppgavebekreftelse } from './hooks/useOppgavebekreftelse';
+import { RegelverkOgInnsynReadMore } from '../../components/readmore/RegelverkOgInnsynReadMore';
+import { getLovLenkerForOppgave } from '../oppgavepaneler/utils/lovverk';
 
 interface OppgaveOgTilbakemeldingProps {
     beskjedFraNav: React.ReactNode;
@@ -94,7 +96,7 @@ const Ubesvart = ({ children }: UbesvartProps) => {
                         </Heading>
                         <Box maxWidth="90%">{children}</Box>
                         <Box marginBlock="space-0 space-16">
-                            <RegelverkOgInnsynReadMore />
+                            <RegelverkOgInnsynReadMore lenker={getLovLenkerForOppgave(oppgave.oppgavetype)} />
                         </Box>
                     </VStack>
                 </GuidePanel>

--- a/packages/ung-innsyn/src/modules/oppgavebekreftelse/OppgavebekreftelseParts.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavebekreftelse/OppgavebekreftelseParts.tsx
@@ -96,7 +96,7 @@ const Ubesvart = ({ children }: UbesvartProps) => {
                         </Heading>
                         <Box maxWidth="90%">{children}</Box>
                         <Box marginBlock="space-0 space-16">
-                            <RegelverkOgInnsynReadMore lenker={getLovLenkerForOppgave(oppgave.oppgavetype)} />
+                            <RegelverkOgInnsynReadMore lenker={getLovLenkerForOppgave(oppgave.parsedOppgavetype)} />
                         </Box>
                     </VStack>
                 </GuidePanel>

--- a/packages/ung-innsyn/src/modules/oppgavebekreftelse/OppgavebekreftelseParts.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavebekreftelse/OppgavebekreftelseParts.tsx
@@ -96,7 +96,10 @@ const Ubesvart = ({ children }: UbesvartProps) => {
                         </Heading>
                         <Box maxWidth="90%">{children}</Box>
                         <Box marginBlock="space-0 space-16">
-                            <RegelverkOgInnsynReadMore lenker={getLovLenkerForOppgave(oppgave.parsedOppgavetype)} />
+                            <RegelverkOgInnsynReadMore
+                                ytelsetype={oppgave.ytelsetype}
+                                lenker={getLovLenkerForOppgave(oppgave.oppgavetype, oppgave.ytelsetype)}
+                            />
                         </Box>
                     </VStack>
                 </GuidePanel>

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/avvik-registerinntekt/AvvikRegisterinntektOppgave.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/avvik-registerinntekt/AvvikRegisterinntektOppgave.stories.tsx
@@ -52,7 +52,7 @@ const registerInntektEnArbeidsgiver: RegisterinntektDto = {
 
 const oppgave: AvvikRegisterinntektOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
     oppgavetypeData: {
         fraOgMed: dayjs('2025-05-01').toDate(),
         tilOgMed: dayjs('2025-05-31').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/avvik-registerinntekt/AvvikRegisterinntektOppgave.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/avvik-registerinntekt/AvvikRegisterinntektOppgave.stories.tsx
@@ -2,6 +2,7 @@ import { Heading, VStack } from '@navikt/ds-react';
 import {
     ArbeidOgFrilansRegisterInntektDto,
     OppgaveStatus,
+    OppgaveType,
     OppgaveYtelsetype,
     RegisterinntektDto,
     YtelseRegisterInntektDto,
@@ -52,6 +53,7 @@ const registerInntektEnArbeidsgiver: RegisterinntektDto = {
 
 const oppgave: AvvikRegisterinntektOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.BEKREFT_AVVIK_REGISTERINNTEKT,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
     oppgavetypeData: {
         fraOgMed: dayjs('2025-05-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/avvik-registerinntekt/i18n/nb.ts
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/avvik-registerinntekt/i18n/nb.ts
@@ -49,8 +49,8 @@ export const avvikRegisterinntektMessages_nb = {
         'Hvis vi ikke hører fra deg innen svarfristen, bruker vi inntekten vi har fått oppgitt.',
 
     '@ungInnsyn.regelverkOgInnsyn.readMore.tittel': 'Regelverk og innsyn',
-    '@ungInnsyn.regelverkOgInnsyn.readMore.aktivitetspenger': 'Se regelverket for ungdomsprogramytelsen:',
-    '@ungInnsyn.regelverkOgInnsyn.readMore.ungdomsytelse': 'Se regelverket for aktivitetspenger:',
+    '@ungInnsyn.regelverkOgInnsyn.readMore.aktivitetspenger': 'Se regelverket for aktivitetspenger:',
+    '@ungInnsyn.regelverkOgInnsyn.readMore.ungdomsytelse': 'Se regelverket for ungdomsprogramytelsen:',
     '@ungInnsyn.regelverkOgInnsyn.readMore.paragraf': '§ 13 fjerde ledd i Arbeidsmarkedsloven (lovdata.no)',
     '@ungInnsyn.regelverkOgInnsyn.readMore.forskrift':
         '§ 11 i Forskrift om forsøk med ungdomsprogram og ungdomsprogramytelse (gjelder fra 1. august 2025) (lovdata.no)',

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/avvik-registerinntekt/i18n/nb.ts
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/avvik-registerinntekt/i18n/nb.ts
@@ -49,7 +49,8 @@ export const avvikRegisterinntektMessages_nb = {
         'Hvis vi ikke hører fra deg innen svarfristen, bruker vi inntekten vi har fått oppgitt.',
 
     '@ungInnsyn.regelverkOgInnsyn.readMore.tittel': 'Regelverk og innsyn',
-    '@ungInnsyn.regelverkOgInnsyn.readMore.tekst.1': 'Se regelverket for ungdomsprogramytelsen:',
+    '@ungInnsyn.regelverkOgInnsyn.readMore.aktivitetspenger': 'Se regelverket for ungdomsprogramytelsen:',
+    '@ungInnsyn.regelverkOgInnsyn.readMore.ungdomsytelse': 'Se regelverket for aktivitetspenger:',
     '@ungInnsyn.regelverkOgInnsyn.readMore.paragraf': '§ 13 fjerde ledd i Arbeidsmarkedsloven (lovdata.no)',
     '@ungInnsyn.regelverkOgInnsyn.readMore.forskrift':
         '§ 11 i Forskrift om forsøk med ungdomsprogram og ungdomsprogramytelse (gjelder fra 1. august 2025) (lovdata.no)',

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/bostedsvilkar/BostedVilkarOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/bostedsvilkar/BostedVilkarOppgavePanel.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj;
 
 const oppgave: BostedVilkårOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.BEKREFT_BOSTED,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_BOSTED,
     status: OppgaveStatus.ULØST,
     opprettetDato: dayjs().subtract(1, 'days').toDate(),
     sisteDatoEnKanSvare: dayjs().add(14, 'days').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/bostedsvilkar/BostedVilkarOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/bostedsvilkar/BostedVilkarOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { BostedVilkårOppgave, ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -20,6 +20,7 @@ type Story = StoryObj;
 
 const oppgave: BostedVilkårOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.BEKREFT_BOSTED,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_BOSTED,
     status: OppgaveStatus.ULØST,
     opprettetDato: dayjs().subtract(1, 'days').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/endret-sluttdato/EndretSluttdatoOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/endret-sluttdato/EndretSluttdatoOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { EndretSluttdatoOppgave, ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -20,6 +20,7 @@ type Story = StoryObj;
 
 const oppgave: EndretSluttdatoOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.BEKREFT_ENDRET_SLUTTDATO,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO,
     oppgavetypeData: {
         nySluttdato: dayjs('2025-05-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/endret-sluttdato/EndretSluttdatoOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/endret-sluttdato/EndretSluttdatoOppgavePanel.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj;
 
 const oppgave: EndretSluttdatoOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO,
     oppgavetypeData: {
         nySluttdato: dayjs('2025-05-01').toDate(),
         forrigeSluttdato: dayjs('2025-04-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/endret-start-og-sluttdato/EndretStartOgSluttdatoOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/endret-start-og-sluttdato/EndretStartOgSluttdatoOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { EndretStartOgSluttdatoOppgave, ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -20,6 +20,7 @@ type Story = StoryObj;
 
 const oppgave: EndretStartOgSluttdatoOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.BEKREFT_ENDRET_PERIODE,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO,
     oppgavetypeData: {
         forrigePeriode: { from: dayjs('2025-05-04').toDate() },

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/endret-start-og-sluttdato/EndretStartOgSluttdatoOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/endret-start-og-sluttdato/EndretStartOgSluttdatoOppgavePanel.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj;
 
 const oppgave: EndretStartOgSluttdatoOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO,
     oppgavetypeData: {
         forrigePeriode: { from: dayjs('2025-05-04').toDate() },
         nyPeriode: {

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/endret-startdato/EndretStartdatoOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/endret-startdato/EndretStartdatoOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { EndretStartdatoOppgave, ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -20,6 +20,7 @@ type Story = StoryObj;
 
 const oppgave: EndretStartdatoOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.BEKREFT_ENDRET_STARTDATO,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO,
     oppgavetypeData: {
         nyStartdato: dayjs('2025-05-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/endret-startdato/EndretStartdatoOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/endret-startdato/EndretStartdatoOppgavePanel.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj;
 
 const oppgave: EndretStartdatoOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO,
     oppgavetypeData: {
         nyStartdato: dayjs('2025-05-01').toDate(),
         forrigeStartdato: dayjs('2025-05-05').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/fjernet-periode/FjernetPeriodeOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/fjernet-periode/FjernetPeriodeOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { FjernetPeriodeOppgave, ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -20,6 +20,7 @@ type Story = StoryObj;
 
 const oppgave: FjernetPeriodeOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.BEKREFT_ENDRET_PERIODE,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_FJERNET_PERIODE,
     status: OppgaveStatus.ULØST,
     opprettetDato: dayjs().subtract(1, 'days').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/fjernet-periode/FjernetPeriodeOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/fjernet-periode/FjernetPeriodeOppgavePanel.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj;
 
 const oppgave: FjernetPeriodeOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.BEKREFT_FJERNET_PERIODE,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_FJERNET_PERIODE,
     status: OppgaveStatus.ULØST,
     opprettetDato: dayjs().subtract(1, 'days').toDate(),
     sisteDatoEnKanSvare: dayjs().add(14, 'days').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/meldt-ut/MeldtUtOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/meldt-ut/MeldtUtOppgavePanel.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj;
 
 const oppgave: MeldtUtOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.BEKREFT_MELDT_UT,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_MELDT_UT,
     oppgavetypeData: {
         sluttdato: dayjs('2025-05-01').toDate(),
     },

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/meldt-ut/MeldtUtOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/meldt-ut/MeldtUtOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { MeldtUtOppgave, ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -19,6 +19,7 @@ type Story = StoryObj;
 
 const oppgave: MeldtUtOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.BEKREFT_ENDRET_PERIODE,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_MELDT_UT,
     oppgavetypeData: {
         sluttdato: dayjs('2025-05-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/meldt-ut/MeldtUtOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/meldt-ut/MeldtUtOppgavePanel.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj;
 
 const oppgave: MeldtUtOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: OppgaveType.BEKREFT_ENDRET_PERIODE,
+    oppgavetype: OppgaveType.BEKREFT_ENDRET_SLUTTDATO,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_MELDT_UT,
     oppgavetypeData: {
         sluttdato: dayjs('2025-05-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/opphor-ved-maksdato/OpphorVedMaksdatoOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/opphor-ved-maksdato/OpphorVedMaksdatoOppgavePanel.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj;
 
 const oppgave: OpphorVedMaksdatoOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO,
+    parsedOppgavetype: ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO,
     oppgavetypeData: {
         maksdato: dayjs('2025-05-01').toDate(),
         sluttdato: dayjs('2025-05-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/opphor-ved-maksdato/OpphorVedMaksdatoOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/opphor-ved-maksdato/OpphorVedMaksdatoOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { OpphorVedMaksdatoOppgave, ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -20,6 +20,7 @@ type Story = StoryObj;
 
 const oppgave: OpphorVedMaksdatoOppgave = {
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.BEKREFT_OPPHOR_VED_MAKSDATO,
     parsedOppgavetype: ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO,
     oppgavetypeData: {
         maksdato: dayjs('2025-05-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/rapporter-inntekt/RapporterInntektOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/rapporter-inntekt/RapporterInntektOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { ParsedOppgavetype, RapporterInntektOppgave } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -20,6 +20,7 @@ type Story = StoryObj;
 const oppgave: RapporterInntektOppgave = {
     oppgaveYtelsetype: OppgaveYtelsetype.UNGDOMSYTELSE,
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
+    oppgavetype: OppgaveType.RAPPORTER_INNTEKT,
     parsedOppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT,
     oppgavetypeData: {
         fraOgMed: dayjs('2025-05-01').toDate(),
@@ -52,6 +53,7 @@ const besvartOppgave: RapporterInntektOppgave = {
 const utløptUbesvartOppgave: RapporterInntektOppgave = {
     oppgaveYtelsetype: OppgaveYtelsetype.UNGDOMSYTELSE,
     oppgaveReferanse: 'ab0a18f8-8a6e-485b-b2b6-8d43a438165d',
+    oppgavetype: OppgaveType.RAPPORTER_INNTEKT,
     parsedOppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT,
     oppgavetypeData: {
         fraOgMed: dayjs('2025-09-01').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/rapporter-inntekt/RapporterInntektOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/rapporter-inntekt/RapporterInntektOppgavePanel.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj;
 const oppgave: RapporterInntektOppgave = {
     oppgaveYtelsetype: OppgaveYtelsetype.UNGDOMSYTELSE,
     oppgaveReferanse: '3d3e98b5-48e7-42c6-9fc1-e0f78022307f',
-    oppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT,
+    parsedOppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT,
     oppgavetypeData: {
         fraOgMed: dayjs('2025-05-01').toDate(),
         tilOgMed: dayjs('2025-05-31').toDate(),
@@ -52,7 +52,7 @@ const besvartOppgave: RapporterInntektOppgave = {
 const utløptUbesvartOppgave: RapporterInntektOppgave = {
     oppgaveYtelsetype: OppgaveYtelsetype.UNGDOMSYTELSE,
     oppgaveReferanse: 'ab0a18f8-8a6e-485b-b2b6-8d43a438165d',
-    oppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT,
+    parsedOppgavetype: ParsedOppgavetype.RAPPORTER_INNTEKT,
     oppgavetypeData: {
         fraOgMed: dayjs('2025-09-01').toDate(),
         tilOgMed: dayjs('2025-09-30').toDate(),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/sok-ytelse/SøkYtelseOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/sok-ytelse/SøkYtelseOppgavePanel.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj;
 
 const oppgave: SøkYtelseOppgave = {
     oppgaveReferanse: 'e632b20a-b0c9-4953-97ec-851ebd1a0e91',
-    oppgavetype: ParsedOppgavetype.SØK_YTELSE,
+    parsedOppgavetype: ParsedOppgavetype.SØK_YTELSE,
     oppgavetypeData: {
         fomDato: new Date('2025-05-01'),
     },

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/sok-ytelse/SøkYtelseOppgavePanel.stories.tsx
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/sok-ytelse/SøkYtelseOppgavePanel.stories.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@navikt/ds-react';
-import { OppgaveStatus, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
+import { OppgaveStatus, OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 import { ParsedOppgavetype, SøkYtelseOppgave } from '@sif/api/ung-brukerdialog';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
@@ -19,6 +19,7 @@ type Story = StoryObj;
 
 const oppgave: SøkYtelseOppgave = {
     oppgaveReferanse: 'e632b20a-b0c9-4953-97ec-851ebd1a0e91',
+    oppgavetype: OppgaveType.SØK_YTELSE,
     parsedOppgavetype: ParsedOppgavetype.SØK_YTELSE,
     oppgavetypeData: {
         fomDato: new Date('2025-05-01'),

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/utils/lovverk.ts
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/utils/lovverk.ts
@@ -1,4 +1,4 @@
-import { ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
+import { OppgaveType, OppgaveYtelsetype } from '@navikt/ung-brukerdialog-api';
 
 export type Lovlenke = {
     url: string;
@@ -49,41 +49,65 @@ Bekreft_automatisk_opphør:
 
  */
 export const LoverOgLenker = {
+    forskriftAktivitetspenger: {
+        url: 'https://www.nav.no#todo',
+        tekst: '[TODO] Forskrift om aktivitetspenger (lovdata.no)',
+    },
     forskriftUngdomsprogrammet: {
         url: 'https://lovdata.no/dokument/LTI/forskrift/2025-06-20-1182',
         tekst: '§ 11 i Forskrift om forsøk med ungdomsprogram og ungdomsprogramytelse (gjelder fra 1. august 2025) (lovdata.no)',
     },
     /** Endret periode upy */
-    arbeidsmarkedslovenParagraf12_13: {
+    arbeidsmarkedslovenP_12_13: {
         url: 'https://lovdata.no/lov/2004-12-10-76/§12',
-        tekst: '§ 12 tredje ledd og § 13 fjerde ledd i arbeidsmarkedsloven',
+        tekst: '§ 12 tredje ledd og § 13 fjerde ledd i arbeidsmarkedsloven (lovdata.no)',
     },
     /** Rapporter inntekt, Avvik inntekt */
-    arbeidsmarkedslovenParagraf13: {
+    arbeidsmarkedslovenP_13: {
         url: 'https://lovdata.no/lov/2004-12-10-76/§13',
-        tekst: '§ 13 fjerde ledd i arbeidsmarkedsloven',
+        tekst: '§ 13 fjerde ledd i arbeidsmarkedsloven (lovdata.no)',
     },
 } satisfies Record<string, Lovlenke>;
 
-export const getLovLenkerForOppgave = (oppgavetype: ParsedOppgavetype): Lovlenke[] => {
+/** Denne er under arbeid frem til alle referanser for aktivitetspenger er avklart */
+export const getLovLenkerForOppgave = (
+    oppgavetype: OppgaveType,
+    oppgaveYtelsetype: OppgaveYtelsetype,
+    /** Settes true hvis en skal returnere lenker ut fra ytelse og oppgavetype */
+    utvidetVersjon: boolean = false,
+): Lovlenke[] => {
+    if (!utvidetVersjon) {
+        return [LoverOgLenker.arbeidsmarkedslovenP_13, LoverOgLenker.forskriftUngdomsprogrammet];
+    }
+    if (!oppgaveYtelsetype) {
+        return [];
+    }
     switch (oppgavetype) {
-        case ParsedOppgavetype.BEKREFT_BOSTED:
-            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
-        case ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO:
-            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
-        case ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO:
-            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
-        case ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO:
-            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
-        case ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO:
-            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
-        case ParsedOppgavetype.RAPPORTER_INNTEKT:
-            return [LoverOgLenker.arbeidsmarkedslovenParagraf13, LoverOgLenker.forskriftUngdomsprogrammet];
-        case ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT:
-            return [LoverOgLenker.arbeidsmarkedslovenParagraf13, LoverOgLenker.forskriftUngdomsprogrammet];
-        case ParsedOppgavetype.SØK_YTELSE:
-            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13];
-        default:
-            return [];
+        /** Aktivitetspenger */
+        case OppgaveType.BEKREFT_BOSTED:
+            return [LoverOgLenker.arbeidsmarkedslovenP_12_13, LoverOgLenker.forskriftAktivitetspenger];
+
+        /** Ungdomsytelse */
+        case OppgaveType.BEKREFT_ENDRET_PERIODE:
+        case OppgaveType.BEKREFT_ENDRET_SLUTTDATO:
+        case OppgaveType.BEKREFT_ENDRET_STARTDATO:
+        case OppgaveType.BEKREFT_OPPHOR_VED_MAKSDATO:
+            return [LoverOgLenker.arbeidsmarkedslovenP_12_13, LoverOgLenker.forskriftUngdomsprogrammet];
+        case OppgaveType.RAPPORTER_INNTEKT:
+            return [LoverOgLenker.arbeidsmarkedslovenP_13, LoverOgLenker.forskriftUngdomsprogrammet];
+
+        /** Felles for aktivitetspenger og ungdomsytelse */
+        case OppgaveType.BEKREFT_AVVIK_REGISTERINNTEKT:
+            if (oppgaveYtelsetype === OppgaveYtelsetype.AKTIVITETSPENGER) {
+                return [LoverOgLenker.arbeidsmarkedslovenP_13, LoverOgLenker.forskriftAktivitetspenger];
+            } else {
+                return [LoverOgLenker.arbeidsmarkedslovenP_13, LoverOgLenker.forskriftUngdomsprogrammet];
+            }
+        case OppgaveType.SØK_YTELSE:
+            if (oppgaveYtelsetype === OppgaveYtelsetype.AKTIVITETSPENGER) {
+                return [LoverOgLenker.arbeidsmarkedslovenP_13, LoverOgLenker.forskriftAktivitetspenger];
+            } else {
+                return [LoverOgLenker.arbeidsmarkedslovenP_13, LoverOgLenker.forskriftUngdomsprogrammet];
+            }
     }
 };

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/utils/lovverk.ts
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/utils/lovverk.ts
@@ -109,5 +109,7 @@ export const getLovLenkerForOppgave = (
             } else {
                 return [LoverOgLenker.arbeidsmarkedslovenP_13, LoverOgLenker.forskriftUngdomsprogrammet];
             }
+        default:
+            return [];
     }
 };

--- a/packages/ung-innsyn/src/modules/oppgavepaneler/utils/lovverk.ts
+++ b/packages/ung-innsyn/src/modules/oppgavepaneler/utils/lovverk.ts
@@ -1,0 +1,89 @@
+import { ParsedOppgavetype } from '@sif/api/ung-brukerdialog';
+
+export type Lovlenke = {
+    url: string;
+    tekst: string;
+};
+
+/**
+ * Bekreft_endret_startdato:
+
+§§ 12 tredje ledd og 13 fjerde ledd i arbeidsmarkedsloven
+§ 8 jf. § 3 og § 6 i Forskrift om forsøk om ungdomsprogram og ungdomsprogramytelse
+
+
+Bekreft_endret_sluttdato:
+
+§§ 12 tredje ledd og 13 fjerde ledd i arbeidsmarkedsloven
+§ 8 jf. § 3 og § 6 i Forskrift om forsøk om ungdomsprogram og ungdomsprogramytelse
+
+
+Bekreft_endret_periode:
+
+§§ 12 tredje ledd og 13 fjerde ledd i arbeidsmarkedsloven
+§ 8 jf. § 3 og § 6 i Forskrift om forsøk om ungdomsprogram og ungdomsprogramytelse
+
+
+Bekreft_avvik_registerinntekt:
+
+§ 13 fjerde ledd i arbeidsmarkedsloven
+§ 11 i Forskrift om forsøk om ungdomsprogram og ungdomsprogramytelse
+
+
+Rapporter_inntekt:
+
+§ 13 fjerde ledd i arbeidsmarkedsloven
+§ 11 i Forskrift om forsøk om ungdomsprogram og ungdomsprogramytelse
+
+
+Søk_ytelse:
+
+§§ 12 tredje ledd og 13 fjerde ledd i arbeidsmarkedsloven
+§ 8 jf. § 3 og §§ 6, 9 og 10 i Forskrift om forsøk om ungdomsprogram og ungdomsprogramytelse
+
+
+Bekreft_automatisk_opphør:
+
+§§ 12 tredje ledd og 13 fjerde ledd i arbeidsmarkedsloven
+§ 8 jf. § 3 i Forskrift om forsøk om ungdomsprogram og ungdomsprogramytelse
+
+ */
+export const LoverOgLenker = {
+    forskriftUngdomsprogrammet: {
+        url: 'https://lovdata.no/dokument/LTI/forskrift/2025-06-20-1182',
+        tekst: '§ 11 i Forskrift om forsøk med ungdomsprogram og ungdomsprogramytelse (gjelder fra 1. august 2025) (lovdata.no)',
+    },
+    /** Endret periode upy */
+    arbeidsmarkedslovenParagraf12_13: {
+        url: 'https://lovdata.no/lov/2004-12-10-76/§12',
+        tekst: '§ 12 tredje ledd og § 13 fjerde ledd i arbeidsmarkedsloven',
+    },
+    /** Rapporter inntekt, Avvik inntekt */
+    arbeidsmarkedslovenParagraf13: {
+        url: 'https://lovdata.no/lov/2004-12-10-76/§13',
+        tekst: '§ 13 fjerde ledd i arbeidsmarkedsloven',
+    },
+} satisfies Record<string, Lovlenke>;
+
+export const getLovLenkerForOppgave = (oppgavetype: ParsedOppgavetype): Lovlenke[] => {
+    switch (oppgavetype) {
+        case ParsedOppgavetype.BEKREFT_BOSTED:
+            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
+        case ParsedOppgavetype.BEKREFT_ENDRET_START_OG_SLUTTDATO:
+            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
+        case ParsedOppgavetype.BEKREFT_ENDRET_SLUTTDATO:
+            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
+        case ParsedOppgavetype.BEKREFT_ENDRET_STARTDATO:
+            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
+        case ParsedOppgavetype.BEKREFT_OPPHOR_VED_MAKSDATO:
+            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13, LoverOgLenker.forskriftUngdomsprogrammet];
+        case ParsedOppgavetype.RAPPORTER_INNTEKT:
+            return [LoverOgLenker.arbeidsmarkedslovenParagraf13, LoverOgLenker.forskriftUngdomsprogrammet];
+        case ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT:
+            return [LoverOgLenker.arbeidsmarkedslovenParagraf13, LoverOgLenker.forskriftUngdomsprogrammet];
+        case ParsedOppgavetype.SØK_YTELSE:
+            return [LoverOgLenker.arbeidsmarkedslovenParagraf12_13];
+        default:
+            return [];
+    }
+};

--- a/packages/ung-innsyn/src/pages/UngOppgavePage.tsx
+++ b/packages/ung-innsyn/src/pages/UngOppgavePage.tsx
@@ -16,7 +16,7 @@ import { UngInnsynPage } from './UngInnsynPage';
 import { OpphorVedMaksdatoOppgavePanel } from '../modules/oppgavepaneler/opphor-ved-maksdato/OpphorVedMaksdatoOppgavePanel';
 
 const getOppgavePageComponent = (navn: string, oppgave: Oppgave): React.JSX.Element => {
-    switch (oppgave.oppgavetype) {
+    switch (oppgave.parsedOppgavetype) {
         case ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT:
             return <AvvikRegisterinntektOppgavePanel oppgave={oppgave} navn={navn} />;
         case ParsedOppgavetype.BEKREFT_BOSTED:

--- a/packages/ung-innsyn/src/utils/textUtils.ts
+++ b/packages/ung-innsyn/src/utils/textUtils.ts
@@ -10,26 +10,26 @@ const renderDatoOgKlokkeslett = (dato?: Date) => {
 };
 
 export const getOppgaveTittel = (oppgave: Oppgave | BekreftelseOppgave, { text }: UngUiIntlShape): string => {
-    switch (oppgave.oppgavetype) {
+    switch (oppgave.parsedOppgavetype) {
         case ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT:
-            return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.oppgavetittel`, {
+            return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.oppgavetittel`, {
                 månedOgÅr: oppgave.oppgavetypeData ? dateFormatter.monthFullYear(oppgave.oppgavetypeData.fraOgMed) : '',
             });
         case ParsedOppgavetype.RAPPORTER_INNTEKT:
-            return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.oppgavetittel`, {
+            return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.oppgavetittel`, {
                 månedOgÅr: oppgave.oppgavetypeData ? dateFormatter.monthFullYear(oppgave.oppgavetypeData.fraOgMed) : '',
                 måned: oppgave.oppgavetypeData ? dateFormatter.month(oppgave.oppgavetypeData.fraOgMed) : '',
             });
         case ParsedOppgavetype.SØK_YTELSE:
-            return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.${oppgave.ytelsetype}.oppgavetittel`);
+            return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.${oppgave.ytelsetype}.oppgavetittel`);
 
         default:
-            return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.oppgavetittel`);
+            return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.oppgavetittel`);
     }
 };
 
 export const getOppgavePanelTittel = (oppgave: Oppgave | BekreftelseOppgave, { text }: UngUiIntlShape): string => {
-    switch (oppgave.oppgavetype) {
+    switch (oppgave.parsedOppgavetype) {
         case ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT:
             return text('@ungInnsyn.oppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT.paneltittel', {
                 månedOgÅr: oppgave.oppgavetypeData ? dateFormatter.monthFullYear(oppgave.oppgavetypeData.fraOgMed) : '',
@@ -40,14 +40,14 @@ export const getOppgavePanelTittel = (oppgave: Oppgave | BekreftelseOppgave, { t
                 måned: oppgave.oppgavetypeData ? dateFormatter.month(oppgave.oppgavetypeData.fraOgMed) : '',
             });
         case ParsedOppgavetype.SØK_YTELSE:
-            return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.${oppgave.ytelsetype}.paneltittel`);
+            return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.${oppgave.ytelsetype}.paneltittel`);
         default:
-            return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.paneltittel`);
+            return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.paneltittel`);
     }
 };
 
 export const getOppgaveInfo = (oppgave: Oppgave, { text }: UngUiIntlShape): string => {
-    switch (oppgave.oppgavetype) {
+    switch (oppgave.parsedOppgavetype) {
         case ParsedOppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT:
             return text('@ungInnsyn.oppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT.info', {
                 måned: dateFormatter.month(oppgave.oppgavetypeData.fraOgMed),
@@ -57,9 +57,9 @@ export const getOppgaveInfo = (oppgave: Oppgave, { text }: UngUiIntlShape): stri
                 måned: dateFormatter.month(oppgave.oppgavetypeData.fraOgMed),
             });
         case ParsedOppgavetype.SØK_YTELSE:
-            return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.${oppgave.ytelsetype}.info`);
+            return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.${oppgave.ytelsetype}.info`);
         default:
-            return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.info`);
+            return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.info`);
     }
 };
 
@@ -77,7 +77,7 @@ export const getOppgaveStatusText = (oppgave: ParsedOppgaveBase): string => {
 };
 
 export const getTilbakemeldingSpørsmål = (oppgave: BekreftelseOppgave, { text }: UngUiIntlShape) => {
-    return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.harTilbakemeldingSpørsmål`);
+    return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.harTilbakemeldingSpørsmål`);
 };
 
 export const getSvaralternativer = (
@@ -85,13 +85,13 @@ export const getSvaralternativer = (
     { text }: UngUiIntlShape,
 ): UttalelseSvaralternativer => {
     return {
-        harIkkeUttalelseLabel: text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.harIkkeUttalelseLabel`),
-        harUttalelseLabel: text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.harUttalelseLabel`),
+        harIkkeUttalelseLabel: text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.harIkkeUttalelseLabel`),
+        harUttalelseLabel: text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.harUttalelseLabel`),
     };
 };
 
 export const getTilbakemeldingFritekstLabel = (oppgave: BekreftelseOppgave, { text }: UngUiIntlShape) => {
-    return text(`@ungInnsyn.oppgavetype.${oppgave.oppgavetype}.tilbakemeldingFritekstLabel`);
+    return text(`@ungInnsyn.oppgavetype.${oppgave.parsedOppgavetype}.tilbakemeldingFritekstLabel`);
 };
 
 export const getOppgaveDokumentTittel = (applikasjonTittel: string, oppgave: Oppgave, intl: UngUiIntlShape) => {


### PR DESCRIPTION
### Behov / Bakgrunn
Lenker til lover og forskrifter for de ulike varslene varierer. Ved innføring av aktivitetspenger vil vi gradvis utvide med flere lenker.

### Løsning
Lage støtte for å utvide hva en lenker til fra de ulike varslene. Enn så lenge togglet vha. egen parameter.

### Andre endringer
Lett refactoring
