### PR TITLE
Prodsette forlengelse 8 uker - ung veileder

### DIFF
--- a/apps-intern/ungdomsytelse-veileder/nais/prod-gcp.json
+++ b/apps-intern/ungdomsytelse-veileder/nais/prod-gcp.json
@@ -26,7 +26,7 @@
         "NPM_CONFIG_CACHE": "/tmp",
         "PUBLIC_PATH": "/",
 
-        "SIF_PUBLIC_FEATURE_FORLENGE_PERIODE": "off",
+        "SIF_PUBLIC_FEATURE_FORLENGE_PERIODE": "on",
         "SIF_PUBLIC_FEATURE_SLETT_AKTIV_DELTAKELSE": "off",
 
         "UNG_DELTAKELSE_OPPLYSER_FRONTEND_PATH": "/api/ung-deltakelse-opplyser",


### PR DESCRIPTION
Prodsette funksjonalitet for å forlenge en deltakelse med inntil 8 uker.
Endre featuretoggle i prod-gcp.