### PR TITLE
Slette filer fra image etter bygg i Dockerfile

### DIFF
--- a/apps-intern/ungdomsytelse-veileder/Dockerfile
+++ b/apps-intern/ungdomsytelse-veileder/Dockerfile
@@ -76,7 +76,13 @@ WORKDIR /app
 ENV SERVER="server-ungdomsytelse-veileder"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Copy server build
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/aktivitetspenger-innsyn/Dockerfile
+++ b/apps/aktivitetspenger-innsyn/Dockerfile
@@ -78,7 +78,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/aktivitetspenger-innsyn/Dockerfile
+++ b/apps/aktivitetspenger-innsyn/Dockerfile
@@ -81,6 +81,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/aktivitetspenger-soknad/Dockerfile
+++ b/apps/aktivitetspenger-soknad/Dockerfile
@@ -78,7 +78,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/aktivitetspenger-soknad/Dockerfile
+++ b/apps/aktivitetspenger-soknad/Dockerfile
@@ -81,6 +81,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/dine-pleiepenger/Dockerfile
+++ b/apps/dine-pleiepenger/Dockerfile
@@ -3,7 +3,11 @@ FROM node:26-alpine
 RUN apk add --no-cache tini \
     && addgroup --system --gid 1069 nodejs \
     && adduser --system --uid 1069 nextjs \
-    && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
+    && rm -rf /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 WORKDIR /app
 

--- a/apps/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn/Dockerfile
+++ b/apps/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn/Dockerfile
+++ b/apps/ekstra-omsorgsdager-andre-forelder-ikke-tilsyn/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/endringsmelding-pleiepenger/Dockerfile
+++ b/apps/endringsmelding-pleiepenger/Dockerfile
@@ -78,7 +78,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/endringsmelding-pleiepenger/Dockerfile
+++ b/apps/endringsmelding-pleiepenger/Dockerfile
@@ -81,6 +81,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/omsorgsdager-aleneomsorg-dialog/Dockerfile
+++ b/apps/omsorgsdager-aleneomsorg-dialog/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/omsorgsdager-aleneomsorg-dialog/Dockerfile
+++ b/apps/omsorgsdager-aleneomsorg-dialog/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/omsorgsdager-kalkulator/Dockerfile
+++ b/apps/omsorgsdager-kalkulator/Dockerfile
@@ -3,7 +3,11 @@ FROM node:26-alpine
 RUN apk add --no-cache tini \
     && addgroup --system --gid 1069 nodejs \
     && adduser --system --uid 1069 nextjs \
-    && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
+    && rm -rf /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 WORKDIR /app
 

--- a/apps/omsorgspengerutbetaling-arbeidstaker-soknad/Dockerfile
+++ b/apps/omsorgspengerutbetaling-arbeidstaker-soknad/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/omsorgspengerutbetaling-arbeidstaker-soknad/Dockerfile
+++ b/apps/omsorgspengerutbetaling-arbeidstaker-soknad/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/omsorgspengerutbetaling-soknad/Dockerfile
+++ b/apps/omsorgspengerutbetaling-soknad/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/omsorgspengerutbetaling-soknad/Dockerfile
+++ b/apps/omsorgspengerutbetaling-soknad/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/omsorgspengesoknad-v2/Dockerfile
+++ b/apps/omsorgspengesoknad-v2/Dockerfile
@@ -78,7 +78,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/omsorgspengesoknad-v2/Dockerfile
+++ b/apps/omsorgspengesoknad-v2/Dockerfile
@@ -81,6 +81,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/omsorgspengesoknad/Dockerfile
+++ b/apps/omsorgspengesoknad/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/omsorgspengesoknad/Dockerfile
+++ b/apps/omsorgspengesoknad/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/opplaringspenger-soknad/Dockerfile
+++ b/apps/opplaringspenger-soknad/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/opplaringspenger-soknad/Dockerfile
+++ b/apps/opplaringspenger-soknad/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/pleiepenger-i-livets-sluttfase-soknad/Dockerfile
+++ b/apps/pleiepenger-i-livets-sluttfase-soknad/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/pleiepenger-i-livets-sluttfase-soknad/Dockerfile
+++ b/apps/pleiepenger-i-livets-sluttfase-soknad/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/pleiepenger-sykt-barn/Dockerfile
+++ b/apps/pleiepenger-sykt-barn/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/pleiepenger-sykt-barn/Dockerfile
+++ b/apps/pleiepenger-sykt-barn/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/sif-demo-app/Dockerfile
+++ b/apps/sif-demo-app/Dockerfile
@@ -78,7 +78,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/sif-demo-app/Dockerfile
+++ b/apps/sif-demo-app/Dockerfile
@@ -81,6 +81,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/sif-ettersending/Dockerfile
+++ b/apps/sif-ettersending/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/sif-ettersending/Dockerfile
+++ b/apps/sif-ettersending/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack

--- a/apps/ungdomsytelse-deltaker/Dockerfile
+++ b/apps/ungdomsytelse-deltaker/Dockerfile
@@ -79,7 +79,12 @@ WORKDIR /app
 ENV SERVER="server"
 
 # Installer kun tini - trenger ikke npm/pnpm i produksjon
-RUN apk add --no-cache tini && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tini \
+    && rm -rf /var/cache/apk/* \
+        /usr/local/lib/node_modules/npm \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack
 
 # Kopier bygget server
 COPY --from=server-build /app/${SERVER}/dist ./

--- a/apps/ungdomsytelse-deltaker/Dockerfile
+++ b/apps/ungdomsytelse-deltaker/Dockerfile
@@ -82,6 +82,7 @@ ENV SERVER="server"
 RUN apk add --no-cache tini \
     && rm -rf /var/cache/apk/* \
         /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
         /usr/local/bin/npm \
         /usr/local/bin/npx \
         /usr/local/bin/corepack


### PR DESCRIPTION
Sletter npm, npx, corepack fra imaget etter bygg for å fjerne filer som har sikkerhet-vulnerabilites.